### PR TITLE
Deactivate javadoc lint for JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${version.plugin.javadoc}</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Otherwise `mvn package` fails.

See for example http://docs.oracle.com/javase/8/docs/technotes/guides/javac/index.html