### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/com/cedarsoftware/util/ByteUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ByteUtilities.java
@@ -86,7 +86,7 @@ public final class ByteUtilities
 	 */
 	private static char convertDigit(final int value)
 	{
-		return _hex[(value & 0x0f)];
+		return _hex[value & 0x0f];
 	}
 
 	/**

--- a/src/main/java/com/cedarsoftware/util/StringUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/StringUtilities.java
@@ -164,7 +164,7 @@ public final class StringUtilities
      */
     private static char convertDigit(int value)
     {
-        return _hex[(value & 0x0f)];
+        return _hex[value & 0x0f];
     }
 
     public static int count(String s, char c)

--- a/src/main/java/com/cedarsoftware/util/UrlUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/UrlUtilities.java
@@ -66,8 +66,8 @@ import java.util.regex.Pattern;
  */
 public final class UrlUtilities
 {
-    public static String globalUserAgent = null;
-    public static String globalReferrer = null;
+    private static String globalUserAgent = null;
+    private static String globalReferrer = null;
     public static final ThreadLocal<String> userAgent = new ThreadLocal<>();
     public static final ThreadLocal<String> referrer = new ThreadLocal<>();
     public static final String SET_COOKIE = "Set-Cookie";
@@ -108,7 +108,7 @@ public final class UrlUtilities
         }
     };
 
-    public static SSLSocketFactory naiveSSLSocketFactory;
+    protected static SSLSocketFactory naiveSSLSocketFactory;
 
     static
     {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck

Please let me know if you have any questions.

Faisal Hameed