### PR TITLE
General code quality fix-3

### DIFF
--- a/src/main/java/com/cedarsoftware/util/Converter.java
+++ b/src/main/java/com/cedarsoftware/util/Converter.java
@@ -301,8 +301,8 @@ public final class Converter
                         return new BigDecimal(((String) fromInstance).trim());
                     }
                     else if (fromInstance instanceof Number)
-                    {
-                        return new BigDecimal(((Number) fromInstance).doubleValue());
+                    {                        
+                        return BigDecimal.valueOf(((Number) fromInstance).doubleValue());
                     }
                     else if (fromInstance instanceof Boolean)
                     {

--- a/src/main/java/com/cedarsoftware/util/DeepEquals.java
+++ b/src/main/java/com/cedarsoftware/util/DeepEquals.java
@@ -50,6 +50,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class DeepEquals
 {
+    private DeepEquals () {}
+    
     private static final Map<Class, Boolean> _customEquals = new ConcurrentHashMap<>();
     private static final Map<Class, Boolean> _customHash = new ConcurrentHashMap<>();
     private static final double doubleEplison = 1e-15;

--- a/src/main/java/com/cedarsoftware/util/UniqueIdGenerator.java
+++ b/src/main/java/com/cedarsoftware/util/UniqueIdGenerator.java
@@ -31,6 +31,8 @@ import java.util.Map;
  */
 public class UniqueIdGenerator
 {
+    private UniqueIdGenerator () {}
+    
     private static int count = 0;
     private static final int lastIp;
     private static final Map<Long, Long> lastId = new LinkedHashMap<Long, Long>()

--- a/src/main/java/com/cedarsoftware/util/UrlInvocationHandler.java
+++ b/src/main/java/com/cedarsoftware/util/UrlInvocationHandler.java
@@ -57,7 +57,7 @@ import java.net.HttpURLConnection;
  */
 public class UrlInvocationHandler implements InvocationHandler
 {
-    public static int SLEEP_TIME = 5000;
+    public static final int SLEEP_TIME = 5000;
     private final Logger LOG = LogManager.getLogger(UrlInvocationHandler.class);
     private final UrlInvocationHandlerStrategy _strategy;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2111 -  "BigDecimal(double)" should not be used.
squid:S1118 - Utility classes should not have public constructors.
squid:S3008 -  Static non-final field names should comply with a naming convention.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2111
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S3008

Please let me know if you have any questions.

Faisal Hameed