### PR TITLE
DeepEquals to handle flyweight Map.Entry implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <version.junit>4.12</version.junit>
         <version.json.io>4.10.0</version.json.io>            <!-- testing only -->
         <version.mockito>1.10.19</version.mockito>
+        <version.agrona>1.0.7</version.agrona>
         <version.java>11</version.java>
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
         <version.plugin.gpg>1.6</version.plugin.gpg>
@@ -242,11 +243,18 @@
             <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.cedarsoftware</groupId>
             <artifactId>json-io</artifactId>
             <version>${version.json.io}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.agrona</groupId>
+            <artifactId>agrona</artifactId>
+            <version>${version.agrona}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/cedarsoftware/util/DeepEquals.java
+++ b/src/main/java/com/cedarsoftware/util/DeepEquals.java
@@ -2,18 +2,7 @@ package com.cedarsoftware.util;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -28,31 +17,31 @@ import java.util.concurrent.ConcurrentHashMap;
  * overide .equals() / .hashCode() to be compared.  For example, testing for
  * existence in a cache.  Relying on an object's identity will not locate an
  * equivalent object in a cache.<br><br>
- *
+ * <p>
  * This method will handle cycles correctly, for example A-&gt;B-&gt;C-&gt;A.  Suppose a and
  * a' are two separate instances of A with the same values for all fields on
  * A, B, and C.  Then a.deepEquals(a') will return true.  It uses cycle detection
  * storing visited objects in a Set to prevent endless loops.
  *
  * @author John DeRegnaucourt (john@cedarsoftware.com)
- *         <br>
- *         Copyright (c) Cedar Software LLC
- *         <br><br>
- *         Licensed under the Apache License, Version 2.0 (the "License");
- *         you may not use this file except in compliance with the License.
- *         You may obtain a copy of the License at
- *         <br><br>
- *         http://www.apache.org/licenses/LICENSE-2.0
- *         <br><br>
- *         Unless required by applicable law or agreed to in writing, software
- *         distributed under the License is distributed on an "AS IS" BASIS,
- *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *         See the License for the specific language governing permissions and
- *         limitations under the License.
+ * <br>
+ * Copyright (c) Cedar Software LLC
+ * <br><br>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <br><br>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <br><br>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-public class DeepEquals
-{
-    private DeepEquals () {}
+public class DeepEquals {
+    private DeepEquals() {
+    }
 
     public static final String IGNORE_CUSTOM_EQUALS = "ignoreCustomEquals";
     public static final String REASON = "REASON";
@@ -62,8 +51,7 @@ public class DeepEquals
     private static final double floatEplison = 1e-6;
     private static final Set<Class> prims = new HashSet<>();
 
-    static
-    {
+    static {
         prims.add(Byte.class);
         prims.add(Integer.class);
         prims.add(Long.class);
@@ -74,21 +62,17 @@ public class DeepEquals
         prims.add(Short.class);
     }
 
-    private final static class DualKey
-    {
+    private final static class DualKey {
         private final Object _key1;
         private final Object _key2;
 
-        private DualKey(Object k1, Object k2)
-        {
+        private DualKey(Object k1, Object k2) {
             _key1 = k1;
             _key2 = k2;
         }
 
-        public boolean equals(Object other)
-        {
-            if (!(other instanceof DualKey))
-            {
+        public boolean equals(Object other) {
+            if (!(other instanceof DualKey)) {
                 return false;
             }
 
@@ -96,8 +80,7 @@ public class DeepEquals
             return _key1 == that._key1 && _key2 == that._key2;
         }
 
-        public int hashCode()
-        {
+        public int hashCode() {
             int h1 = _key1 != null ? _key1.hashCode() : 0;
             int h2 = _key2 != null ? _key2.hashCode() : 0;
             return h1 + h2;
@@ -116,11 +99,12 @@ public class DeepEquals
      * overide .equals() / .hashCode() to be compared.  For example, testing for
      * existence in a cache.  Relying on an objects identity will not locate an
      * object in cache, yet relying on it being equivalent will.<br><br>
-     *
+     * <p>
      * This method will handle cycles correctly, for example A-&gt;B-&gt;C-&gt;A.  Suppose a and
      * a' are two separate instances of the A with the same values for all fields on
      * A, B, and C.  Then a.deepEquals(a') will return true.  It uses cycle detection
      * storing visited objects in a Set to prevent endless loops.
+     *
      * @param a Object one to compare
      * @param b Object two to compare
      * @return true if a is equivalent to b, false otherwise.  Equivalent means that
@@ -128,8 +112,7 @@ public class DeepEquals
      * or via the respectively encountered overridden .equals() methods during
      * traversal.
      */
-    public static boolean deepEquals(Object a, Object b)
-    {
+    public static boolean deepEquals(Object a, Object b) {
         return deepEquals(a, b, new HashMap());
     }
 
@@ -145,13 +128,14 @@ public class DeepEquals
      * overide .equals() / .hashCode() to be compared.  For example, testing for
      * existence in a cache.  Relying on an objects identity will not locate an
      * object in cache, yet relying on it being equivalent will.<br><br>
-     *
+     * <p>
      * This method will handle cycles correctly, for example A-&gt;B-&gt;C-&gt;A.  Suppose a and
      * a' are two separate instances of the A with the same values for all fields on
      * A, B, and C.  Then a.deepEquals(a') will return true.  It uses cycle detection
      * storing visited objects in a Set to prevent endless loops.
-     * @param a Object one to compare
-     * @param b Object two to compare
+     *
+     * @param a       Object one to compare
+     * @param b       Object two to compare
      * @param options Map options for compare. With no option, if a custom equals()
      *                method is present, it will be used.  If IGNORE_CUSTOM_EQUALS is
      *                present, it will be expected to be a Set of classes to ignore.
@@ -159,14 +143,12 @@ public class DeepEquals
      *                using .equals() even if the classes have a custom .equals() method
      *                present.  If it is and empty set, then no custom .equals() methods
      *                will be called.
-     *
      * @return true if a is equivalent to b, false otherwise.  Equivalent means that
      * all field values of both subgraphs are the same, either at the field level
      * or via the respectively encountered overridden .equals() methods during
      * traversal.
      */
-    public static boolean deepEquals(Object a, Object b, Map options)
-    {
+    public static boolean deepEquals(Object a, Object b, Map options) {
         Set<DualKey> visited = new HashSet<>();
         Deque<DualKey> stack = new LinkedList<>();
         Deque<String> history = new LinkedList<>();
@@ -174,102 +156,76 @@ public class DeepEquals
         stack.addFirst(new DualKey(a, b));
         history.add(getHistoryKey("root", a));
 
-        while (!stack.isEmpty())
-        {
+        while (!stack.isEmpty()) {
             DualKey dualKey = stack.removeFirst();
             visited.add(dualKey);
 
-            if (dualKey._key1 == dualKey._key2)
-            {   // Same instance is always equal to itself.
+            if (dualKey._key1 == dualKey._key2) {   // Same instance is always equal to itself.
                 continue;
             }
 
-            if (dualKey._key1 == null || dualKey._key2 == null)
-            {   // If either one is null, not equal (both can't be null, due to above comparison).
+            if (dualKey._key1 == null || dualKey._key2 == null) {   // If either one is null, not equal (both can't be null, due to above comparison).
                 return false;
             }
 
-            if (dualKey._key1 instanceof Double && compareFloatingPointNumbers(dualKey._key1, dualKey._key2, doubleEplison))
-            {
+            if (dualKey._key1 instanceof Double && compareFloatingPointNumbers(dualKey._key1, dualKey._key2, doubleEplison)) {
                 continue;
             }
 
-            if (dualKey._key1 instanceof Float && compareFloatingPointNumbers(dualKey._key1, dualKey._key2, floatEplison))
-            {
+            if (dualKey._key1 instanceof Float && compareFloatingPointNumbers(dualKey._key1, dualKey._key2, floatEplison)) {
                 continue;
             }
 
             Class key1Class = dualKey._key1.getClass();
 
-            if (key1Class.isPrimitive() || prims.contains(key1Class) || dualKey._key1 instanceof String || dualKey._key1 instanceof Date || dualKey._key1 instanceof Class)
-            {
-                if (!dualKey._key1.equals(dualKey._key2))
-                {
+            if (key1Class.isPrimitive() || prims.contains(key1Class) || dualKey._key1 instanceof String || dualKey._key1 instanceof Date || dualKey._key1 instanceof Class) {
+                if (!dualKey._key1.equals(dualKey._key2)) {
                     return false;
                 }
                 continue;   // Nothing further to push on the stack
             }
-            
-            if (dualKey._key1 instanceof Collection)
-            {   // If Collections, they both must be Collection
-                if (!(dualKey._key2 instanceof Collection))
-                {
+
+            if (dualKey._key1 instanceof Collection) {   // If Collections, they both must be Collection
+                if (!(dualKey._key2 instanceof Collection)) {
                     return false;
                 }
-            }
-            else if (dualKey._key2 instanceof Collection)
-            {   // They both must be Collection
+            } else if (dualKey._key2 instanceof Collection) {   // They both must be Collection
                 return false;
             }
 
-            if (dualKey._key1 instanceof SortedSet)
-            {
-                if (!(dualKey._key2 instanceof SortedSet))
-                {
+            if (dualKey._key1 instanceof SortedSet) {
+                if (!(dualKey._key2 instanceof SortedSet)) {
                     return false;
                 }
-            }
-            else if (dualKey._key2 instanceof SortedSet)
-            {
+            } else if (dualKey._key2 instanceof SortedSet) {
                 return false;
             }
 
-            if (dualKey._key1 instanceof SortedMap)
-            {
-                if (!(dualKey._key2 instanceof SortedMap))
-                {
+            if (dualKey._key1 instanceof SortedMap) {
+                if (!(dualKey._key2 instanceof SortedMap)) {
                     return false;
                 }
-            }
-            else if (dualKey._key2 instanceof SortedMap)
-            {
+            } else if (dualKey._key2 instanceof SortedMap) {
                 return false;
             }
 
-            if (dualKey._key1 instanceof Map)
-            {
-                if (!(dualKey._key2 instanceof Map))
-                {
+            if (dualKey._key1 instanceof Map) {
+                if (!(dualKey._key2 instanceof Map)) {
                     return false;
                 }
-            }
-            else if (dualKey._key2 instanceof Map)
-            {
+            } else if (dualKey._key2 instanceof Map) {
                 return false;
             }
 
-            if (!isContainerType(dualKey._key1) && !isContainerType(dualKey._key2) && !key1Class.equals(dualKey._key2.getClass()))
-            {   // Must be same class
+            if (!isContainerType(dualKey._key1) && !isContainerType(dualKey._key2) && !key1Class.equals(dualKey._key2.getClass())) {   // Must be same class
                 return false;
             }
 
             // Handle all [] types.  In order to be equal, the arrays must be the same
             // length, be of the same type, be in the same order, and all elements within
             // the array must be deeply equivalent.
-            if (key1Class.isArray())
-            {
-                if (!compareArrays(dualKey._key1, dualKey._key2, stack, visited))
-                {
+            if (key1Class.isArray()) {
+                if (!compareArrays(dualKey._key1, dualKey._key2, stack, visited)) {
                     return false;
                 }
                 continue;
@@ -277,10 +233,8 @@ public class DeepEquals
 
             // Special handle SortedSets because they are fast to compare because their
             // elements must be in the same order to be equivalent Sets.
-            if (dualKey._key1 instanceof SortedSet)
-            {
-                if (!compareOrderedCollection((Collection) dualKey._key1, (Collection) dualKey._key2, stack, visited))
-                {
+            if (dualKey._key1 instanceof SortedSet) {
+                if (!compareOrderedCollection((Collection) dualKey._key1, (Collection) dualKey._key2, stack, visited)) {
                     return false;
                 }
                 continue;
@@ -288,10 +242,8 @@ public class DeepEquals
 
             // Handled unordered Sets.  This is a slightly more expensive comparison because order cannot
             // be assumed, a temporary Map must be created, however the comparison still runs in O(N) time.
-            if (dualKey._key1 instanceof Set)
-            {
-                if (!compareUnorderedCollection((Collection) dualKey._key1, (Collection) dualKey._key2, stack, visited))
-                {
+            if (dualKey._key1 instanceof Set) {
+                if (!compareUnorderedCollection((Collection) dualKey._key1, (Collection) dualKey._key2, stack, visited)) {
                     return false;
                 }
                 continue;
@@ -299,10 +251,8 @@ public class DeepEquals
 
             // Check any Collection that is not a Set.  In these cases, element order
             // matters, therefore this comparison is faster than using unordered comparison.
-            if (dualKey._key1 instanceof Collection)
-            {
-                if (!compareOrderedCollection((Collection) dualKey._key1, (Collection) dualKey._key2, stack, visited))
-                {
+            if (dualKey._key1 instanceof Collection) {
+                if (!compareOrderedCollection((Collection) dualKey._key1, (Collection) dualKey._key2, stack, visited)) {
                     return false;
                 }
                 continue;
@@ -310,10 +260,8 @@ public class DeepEquals
 
             // Compare two SortedMaps.  This takes advantage of the fact that these
             // Maps can be compared in O(N) time due to their ordering.
-            if (dualKey._key1 instanceof SortedMap)
-            {
-                if (!compareSortedMap((SortedMap) dualKey._key1, (SortedMap) dualKey._key2, stack, visited))
-                {
+            if (dualKey._key1 instanceof SortedMap) {
+                if (!compareSortedMap((SortedMap) dualKey._key1, (SortedMap) dualKey._key2, stack, visited)) {
                     return false;
                 }
                 continue;
@@ -322,10 +270,8 @@ public class DeepEquals
             // Compare two Unordered Maps. This is a slightly more expensive comparison because
             // order cannot be assumed, therefore a temporary Map must be created, however the
             // comparison still runs in O(N) time.
-            if (dualKey._key1 instanceof Map)
-            {
-                if (!compareUnorderedMap((Map) dualKey._key1, (Map) dualKey._key2, stack, visited))
-                {
+            if (dualKey._key1 instanceof Map) {
+                if (!compareUnorderedMap((Map) dualKey._key1, (Map) dualKey._key2, stack, visited)) {
                     return false;
                 }
                 continue;
@@ -335,12 +281,9 @@ public class DeepEquals
             // the caller has not specified any classes to skip ... OR
             // the caller has specified come classes to ignore and this one is not in the list ... THEN
             // compare using the custom equals.
-            if (hasCustomEquals(key1Class))
-            {
-                if (ignoreCustomEquals == null || (ignoreCustomEquals.size() > 0 && !ignoreCustomEquals.contains(key1Class)))
-                {
-                    if (!dualKey._key1.equals(dualKey._key2))
-                    {
+            if (hasCustomEquals(key1Class)) {
+                if (ignoreCustomEquals == null || (ignoreCustomEquals.size() > 0 && !ignoreCustomEquals.contains(key1Class))) {
+                    if (!dualKey._key1.equals(dualKey._key2)) {
                         return false;
                     }
                     continue;
@@ -349,72 +292,59 @@ public class DeepEquals
 
             Collection<Field> fields = ReflectionUtils.getDeepDeclaredFields(key1Class);
 
-            for (Field field : fields)
-            {
-                try
-                {
+            for (Field field : fields) {
+                try {
                     DualKey dk = new DualKey(field.get(dualKey._key1), field.get(dualKey._key2));
-                    if (!visited.contains(dk))
-                    {
+                    if (!visited.contains(dk)) {
                         stack.addFirst(dk);
                     }
+                } catch (Exception ignored) {
                 }
-                catch (Exception ignored)
-                { }
             }
         }
 
         return true;
     }
 
-    public static boolean isContainerType(Object o)
-    {
+    public static boolean isContainerType(Object o) {
         return o instanceof Collection || o instanceof Map;
     }
 
-    private static String getHistoryKey(String field, Object value)
-    {
-        if (value == null)
-        {
+    private static String getHistoryKey(String field, Object value) {
+        if (value == null) {
             return field + ": null";
         }
-        
+
         Class clazz = value.getClass();
 
-        if (clazz.isPrimitive() || prims.contains(clazz))
-        {
+        if (clazz.isPrimitive() || prims.contains(clazz)) {
             return field + ": [" + clazz.getName() + "] " + value;
-        }
-        else
-        {
+        } else {
             return field + ": [" + clazz.getName() + "]";
         }
     }
-    
+
     /**
      * Deeply compare to Arrays []. Both arrays must be of the same type, same length, and all
      * elements within the arrays must be deeply equal in order to return true.
-     * @param array1 [] type (Object[], String[], etc.)
-     * @param array2 [] type (Object[], String[], etc.)
-     * @param stack add items to compare to the Stack (Stack versus recursion)
+     *
+     * @param array1  [] type (Object[], String[], etc.)
+     * @param array2  [] type (Object[], String[], etc.)
+     * @param stack   add items to compare to the Stack (Stack versus recursion)
      * @param visited Set of objects already compared (prevents cycles)
      * @return true if the two arrays are the same length and contain deeply equivalent items.
      */
-    private static boolean compareArrays(Object array1, Object array2, Deque stack, Set visited)
-    {
+    private static boolean compareArrays(Object array1, Object array2, Deque stack, Set visited) {
         // Same instance check already performed...
 
         int len = Array.getLength(array1);
-        if (len != Array.getLength(array2))
-        {
+        if (len != Array.getLength(array2)) {
             return false;
         }
 
-        for (int i = 0; i < len; i++)
-        {
+        for (int i = 0; i < len; i++) {
             DualKey dk = new DualKey(Array.get(array1, i), Array.get(array2, i));
-            if (!visited.contains(dk))
-            {   // push contents for further comparison
+            if (!visited.contains(dk)) {   // push contents for further comparison
                 stack.addFirst(dk);
             }
         }
@@ -423,30 +353,27 @@ public class DeepEquals
 
     /**
      * Deeply compare two Collections that must be same length and in same order.
-     * @param col1 First collection of items to compare
-     * @param col2 Second collection of items to compare
-     * @param stack add items to compare to the Stack (Stack versus recursion)
+     *
+     * @param col1    First collection of items to compare
+     * @param col2    Second collection of items to compare
+     * @param stack   add items to compare to the Stack (Stack versus recursion)
      * @param visited Set of objects already compared (prevents cycles)
-     * value of 'true' indicates that the Collections may be equal, and the sets
-     * items will be added to the Stack for further comparison.
+     *                value of 'true' indicates that the Collections may be equal, and the sets
+     *                items will be added to the Stack for further comparison.
      */
-    private static boolean compareOrderedCollection(Collection col1, Collection col2, Deque stack, Set visited)
-    {
+    private static boolean compareOrderedCollection(Collection col1, Collection col2, Deque stack, Set visited) {
         // Same instance check already performed...
 
-        if (col1.size() != col2.size())
-        {
+        if (col1.size() != col2.size()) {
             return false;
         }
 
         Iterator i1 = col1.iterator();
         Iterator i2 = col2.iterator();
 
-        while (i1.hasNext())
-        {
+        while (i1.hasNext()) {
             DualKey dk = new DualKey(i1.next(), i2.next());
-            if (!visited.contains(dk))
-            {   // push contents for further comparison
+            if (!visited.contains(dk)) {   // push contents for further comparison
                 stack.addFirst(dk);
             }
         }
@@ -460,58 +387,48 @@ public class DeepEquals
      * can walk the other collection and look for each item in the map, which
      * runs in O(N) time, rather than an O(N^2) lookup that would occur if each
      * item from collection one was scanned for in collection two.
-     * @param col1 First collection of items to compare
-     * @param col2 Second collection of items to compare
-     * @param stack add items to compare to the Stack (Stack versus recursion)
+     *
+     * @param col1    First collection of items to compare
+     * @param col2    Second collection of items to compare
+     * @param stack   add items to compare to the Stack (Stack versus recursion)
      * @param visited Set containing items that have already been compared,
-     * so as to prevent cycles.
+     *                so as to prevent cycles.
      * @return boolean false if the Collections are for certain not equals. A
      * value of 'true' indicates that the Collections may be equal, and the sets
      * items will be added to the Stack for further comparison.
      */
-    private static boolean compareUnorderedCollection(Collection col1, Collection col2, Deque stack, Set visited)
-    {
+    private static boolean compareUnorderedCollection(Collection col1, Collection col2, Deque stack, Set visited) {
         // Same instance check already performed...
 
-        if (col1.size() != col2.size())
-        {
+        if (col1.size() != col2.size()) {
             return false;
         }
 
         Map<Integer, Collection> fastLookup = new HashMap<>();
-        for (Object o : col2)
-        {
+        for (Object o : col2) {
             int hash = deepHashCode(o);
             Collection items = fastLookup.get(hash);
-            if (items == null)
-            {
+            if (items == null) {
                 items = new ArrayList();
                 fastLookup.put(hash, items);
             }
             items.add(o);
         }
 
-        for (Object o : col1)
-        {
+        for (Object o : col1) {
             Collection other = fastLookup.get(deepHashCode(o));
-            if (other == null || other.isEmpty())
-            {   // fail fast: item not even found in other Collection, no need to continue.
+            if (other == null || other.isEmpty()) {   // fail fast: item not even found in other Collection, no need to continue.
                 return false;
             }
 
-            if (other.size() == 1)
-            {   // no hash collision, items must be equivalent or deepEquals is false
+            if (other.size() == 1) {   // no hash collision, items must be equivalent or deepEquals is false
                 DualKey dk = new DualKey(o, other.iterator().next());
-                if (!visited.contains(dk))
-                {   // Place items on 'stack' for future equality comparison.
+                if (!visited.contains(dk)) {   // Place items on 'stack' for future equality comparison.
                     stack.addFirst(dk);
                 }
-            }
-            else
-            {   // hash collision: try all collided items against the current item (if 1 equals, we are good - remove it
+            } else {   // hash collision: try all collided items against the current item (if 1 equals, we are good - remove it
                 // from collision list, making further comparisons faster)
-                if (!isContained(o, other))
-                {
+                if (!isContained(o, other)) {
                     return false;
                 }
             }
@@ -522,40 +439,36 @@ public class DeepEquals
     /**
      * Deeply compare two SortedMap instances.  This method walks the Maps in order,
      * taking advantage of the fact that the Maps are SortedMaps.
-     * @param map1 SortedMap one
-     * @param map2 SortedMap two
-     * @param stack add items to compare to the Stack (Stack versus recursion)
+     *
+     * @param map1    SortedMap one
+     * @param map2    SortedMap two
+     * @param stack   add items to compare to the Stack (Stack versus recursion)
      * @param visited Set containing items that have already been compared, to prevent cycles.
      * @return false if the Maps are for certain not equals.  'true' indicates that 'on the surface' the maps
      * are equal, however, it will place the contents of the Maps on the stack for further comparisons.
      */
-    private static boolean compareSortedMap(SortedMap map1, SortedMap map2, Deque stack, Set visited)
-    {
+    private static boolean compareSortedMap(SortedMap map1, SortedMap map2, Deque stack, Set visited) {
         // Same instance check already performed...
 
-        if (map1.size() != map2.size())
-        {
+        if (map1.size() != map2.size()) {
             return false;
         }
 
         Iterator i1 = map1.entrySet().iterator();
         Iterator i2 = map2.entrySet().iterator();
 
-        while (i1.hasNext())
-        {
-            Map.Entry entry1 = (Map.Entry)i1.next();
-            Map.Entry entry2 = (Map.Entry)i2.next();
+        while (i1.hasNext()) {
+            Map.Entry entry1 = (Map.Entry) i1.next();
+            Map.Entry entry2 = (Map.Entry) i2.next();
 
             // Must split the Key and Value so that Map.Entry's equals() method is not used.
             DualKey dk = new DualKey(entry1.getKey(), entry2.getKey());
-            if (!visited.contains(dk))
-            {   // Push Keys for further comparison
+            if (!visited.contains(dk)) {   // Push Keys for further comparison
                 stack.addFirst(dk);
             }
 
             dk = new DualKey(entry1.getValue(), entry2.getValue());
-            if (!visited.contains(dk))
-            {   // Push values for further comparison
+            if (!visited.contains(dk)) {   // Push values for further comparison
                 stack.addFirst(dk);
             }
         }
@@ -565,64 +478,57 @@ public class DeepEquals
     /**
      * Deeply compare two Map instances.  After quick short-circuit tests, this method
      * uses a temporary Map so that this method can run in O(N) time.
-     * @param map1 Map one
-     * @param map2 Map two
-     * @param stack add items to compare to the Stack (Stack versus recursion)
+     *
+     * @param map1    Map one
+     * @param map2    Map two
+     * @param stack   add items to compare to the Stack (Stack versus recursion)
      * @param visited Set containing items that have already been compared, to prevent cycles.
      * @return false if the Maps are for certain not equals.  'true' indicates that 'on the surface' the maps
      * are equal, however, it will place the contents of the Maps on the stack for further comparisons.
      */
-    private static boolean compareUnorderedMap(Map map1, Map map2, Deque stack, Set visited)
-    {
+    private static boolean compareUnorderedMap(Map map1, Map map2, Deque stack, Set visited) {
         // Same instance check already performed...
 
-        if (map1.size() != map2.size())
-        {
+        if (map1.size() != map2.size()) {
             return false;
         }
 
         Map<Integer, Collection<Map.Entry>> fastLookup = new HashMap<>();
-
-        for (Map.Entry entry : (Set<Map.Entry>)map2.entrySet())
-        {
+        for (Map.Entry entry : (Set<Map.Entry>) map2.entrySet()) {
             int hash = deepHashCode(entry.getKey());
             Collection items = fastLookup.get(hash);
-            if (items == null)
-            {
+            if (items == null) {
                 items = new ArrayList();
                 fastLookup.put(hash, items);
             }
-            items.add(entry);
+
+            // Some map implementations (e.g. agrona Object2ObjectHashMap)
+            // use same flyweight entry instance to reduce garbage.
+            // Take shallow copy to deal with that, otherwise all entries in the list
+            // would be same reference wrapping last element of the iterator
+            items.add(new AbstractMap.SimpleEntry(entry.getKey(), entry.getValue()));
         }
 
-        for (Map.Entry entry : (Set<Map.Entry>)map1.entrySet())
-        {
+        for (Map.Entry entry : (Set<Map.Entry>) map1.entrySet()) {
             Collection<Map.Entry> other = fastLookup.get(deepHashCode(entry.getKey()));
-            if (other == null || other.isEmpty())
-            {
+            if (other == null || other.isEmpty()) {
                 return false;
             }
 
-            if (other.size() == 1)
-            {
+            if (other.size() == 1) {
                 Map.Entry entry2 = other.iterator().next();
                 DualKey dk = new DualKey(entry.getKey(), entry2.getKey());
-                if (!visited.contains(dk))
-                {   // Push keys for further comparison
+                if (!visited.contains(dk)) {   // Push keys for further comparison
                     stack.addFirst(dk);
                 }
 
                 dk = new DualKey(entry.getValue(), entry2.getValue());
-                if (!visited.contains(dk))
-                {   // Push values for further comparison
+                if (!visited.contains(dk)) {   // Push values for further comparison
                     stack.addFirst(dk);
                 }
-            }
-            else
-            {   // hash collision: try all collided items against the current item (if 1 equals, we are good - remove it
+            } else {   // hash collision: try all collided items against the current item (if 1 equals, we are good - remove it
                 // from collision list, making further comparisons faster)
-                if (!isContained(entry, other))
-                {
+                if (!isContained(new AbstractMap.SimpleEntry(entry.getKey(), entry.getValue()), other)) {
                     return false;
                 }
             }
@@ -635,15 +541,12 @@ public class DeepEquals
      * @return true of the passed in o is within the passed in Collection, using a deepEquals comparison
      * element by element.  Used only for hash collisions.
      */
-    private static boolean isContained(Object o, Collection other)
-    {
+    private static boolean isContained(Object o, Collection other) {
         boolean found = false;
         Iterator i = other.iterator();
-        while (i.hasNext())
-        {
+        while (i.hasNext()) {
             Object x = i.next();
-            if (DeepEquals.deepEquals(o, x))
-            {
+            if (DeepEquals.deepEquals(o, x)) {
                 found = true;
                 i.remove(); // can only be used successfully once - remove from list
                 break;
@@ -655,8 +558,7 @@ public class DeepEquals
     /**
      * Compare if two floating point numbers are within a given range
      */
-    private static boolean compareFloatingPointNumbers(Object a, Object b, double epsilon)
-    {
+    private static boolean compareFloatingPointNumbers(Object a, Object b, double epsilon) {
         double a1 = a instanceof Double ? (Double) a : (Float) a;
         double b1 = b instanceof Double ? (Double) b : (Float) b;
         return nearlyEqual(a1, b1, epsilon);
@@ -671,24 +573,18 @@ public class DeepEquals
      * @param epsilon double tolerance value
      * @return true if a and b are close enough
      */
-    private static boolean nearlyEqual(double a, double b, double epsilon)
-    {
+    private static boolean nearlyEqual(double a, double b, double epsilon) {
         final double absA = Math.abs(a);
         final double absB = Math.abs(b);
         final double diff = Math.abs(a - b);
 
-        if (a == b)
-        { // shortcut, handles infinities
+        if (a == b) { // shortcut, handles infinities
             return true;
-        }
-        else if (a == 0 || b == 0 || diff < Double.MIN_NORMAL)
-        {
+        } else if (a == 0 || b == 0 || diff < Double.MIN_NORMAL) {
             // a or b is zero or both are extremely close to it
             // relative error is less meaningful here
             return diff < (epsilon * Double.MIN_NORMAL);
-        }
-        else
-        { // use relative error
+        } else { // use relative error
             return diff / (absA + absB) < epsilon;
         }
     }
@@ -697,27 +593,24 @@ public class DeepEquals
      * Determine if the passed in class has a non-Object.equals() method.  This
      * method caches its results in static ConcurrentHashMap to benefit
      * execution performance.
+     *
      * @param c Class to check.
      * @return true, if the passed in Class has a .equals() method somewhere between
      * itself and just below Object in it's inheritance.
      */
-    public static boolean hasCustomEquals(Class c)
-    {
+    public static boolean hasCustomEquals(Class c) {
         Class origClass = c;
-        if (_customEquals.containsKey(c))
-        {
+        if (_customEquals.containsKey(c)) {
             return _customEquals.get(c);
         }
 
-        while (!Object.class.equals(c))
-        {
-            try
-            {
+        while (!Object.class.equals(c)) {
+            try {
                 c.getDeclaredMethod("equals", Object.class);
                 _customEquals.put(origClass, true);
                 return true;
+            } catch (Exception ignored) {
             }
-            catch (Exception ignored) { }
             c = c.getSuperclass();
         }
         _customEquals.put(origClass, false);
@@ -731,77 +624,67 @@ public class DeepEquals
      * memory location of an object (what identity it was assigned), whereas
      * this method will produce the same hashCode for any object graph, regardless
      * of how many times it is created.<br><br>
-     *
+     * <p>
      * This method will handle cycles correctly (A-&gt;B-&gt;C-&gt;A).  In this case,
      * Starting with object A, B, or C would yield the same hashCode.  If an
      * object encountered (root, suboject, etc.) has a hashCode() method on it
      * (that is not Object.hashCode()), that hashCode() method will be called
      * and it will stop traversal on that branch.
+     *
      * @param obj Object who hashCode is desired.
      * @return the 'deep' hashCode value for the passed in object.
      */
-    public static int deepHashCode(Object obj)
-    {
+    public static int deepHashCode(Object obj) {
         Set<Object> visited = new HashSet<>();
         LinkedList<Object> stack = new LinkedList<>();
         stack.addFirst(obj);
         int hash = 0;
 
-        while (!stack.isEmpty())
-        {
+        while (!stack.isEmpty()) {
             obj = stack.removeFirst();
-            if (obj == null || visited.contains(obj))
-            {
+            if (obj == null || visited.contains(obj)) {
                 continue;
             }
 
             visited.add(obj);
 
-            if (obj.getClass().isArray())
-            {
+            if (obj.getClass().isArray()) {
                 int len = Array.getLength(obj);
-                for (int i = 0; i < len; i++)
-                {
+                for (int i = 0; i < len; i++) {
                     stack.addFirst(Array.get(obj, i));
                 }
                 continue;
             }
 
-            if (obj instanceof Collection)
-            {
-                stack.addAll(0, (Collection)obj);
+            if (obj instanceof Collection) {
+                stack.addAll(0, (Collection) obj);
                 continue;
             }
 
-            if (obj instanceof Map)
-            {
-                stack.addAll(0, ((Map)obj).keySet());
-                stack.addAll(0, ((Map)obj).values());
+            if (obj instanceof Map) {
+                stack.addAll(0, ((Map) obj).keySet());
+                stack.addAll(0, ((Map) obj).values());
                 continue;
             }
 
-            if (obj instanceof Double || obj instanceof Float)
-            {
+            if (obj instanceof Double || obj instanceof Float) {
                 // just take the integral value for hashcode
                 // equality tests things more comprehensively
                 stack.add(Math.round(((Number) obj).doubleValue()));
                 continue;
             }
 
-            if (hasCustomHashCode(obj.getClass()))
-            {   // A real hashCode() method exists, call it.
+            if (hasCustomHashCode(obj.getClass())) {   // A real hashCode() method exists, call it.
                 hash += obj.hashCode();
                 continue;
             }
 
             Collection<Field> fields = ReflectionUtils.getDeepDeclaredFields(obj.getClass());
-            for (Field field : fields)
-            {
-                try
-                {
+            for (Field field : fields) {
+                try {
                     stack.addFirst(field.get(obj));
+                } catch (Exception ignored) {
                 }
-                catch (Exception ignored) { }
             }
         }
         return hash;
@@ -811,27 +694,24 @@ public class DeepEquals
      * Determine if the passed in class has a non-Object.hashCode() method.  This
      * method caches its results in static ConcurrentHashMap to benefit
      * execution performance.
+     *
      * @param c Class to check.
      * @return true, if the passed in Class has a .hashCode() method somewhere between
      * itself and just below Object in it's inheritance.
      */
-    public static boolean hasCustomHashCode(Class c)
-    {
+    public static boolean hasCustomHashCode(Class c) {
         Class origClass = c;
-        if (_customHash.containsKey(c))
-        {
+        if (_customHash.containsKey(c)) {
             return _customHash.get(c);
         }
 
-        while (!Object.class.equals(c))
-        {
-            try
-            {
+        while (!Object.class.equals(c)) {
+            try {
                 c.getDeclaredMethod("hashCode");
                 _customHash.put(origClass, true);
                 return true;
+            } catch (Exception ignored) {
             }
-            catch (Exception ignored) { }
             c = c.getSuperclass();
         }
         _customHash.put(origClass, false);

--- a/src/test/java/com/cedarsoftware/util/TestDeepEquals.java
+++ b/src/test/java/com/cedarsoftware/util/TestDeepEquals.java
@@ -1,5 +1,6 @@
 package com.cedarsoftware.util;
 
+import org.agrona.collections.Object2ObjectHashMap;
 import org.junit.Test;
 
 import java.awt.*;
@@ -219,6 +220,14 @@ public class TestDeepEquals
         fillMap(map1);
         map2 = new TreeMap();
         map2 = Collections.synchronizedSortedMap((SortedMap) map2);
+        fillMap(map2);
+        assertTrue(DeepEquals.deepEquals(map1, map2));
+        assertEquals(DeepEquals.deepHashCode(map1), DeepEquals.deepHashCode(map2));
+
+        // Uses flyweight entries
+        map1 = new Object2ObjectHashMap();
+        fillMap(map1);
+        map2 = new Object2ObjectHashMap();
         fillMap(map2);
         assertTrue(DeepEquals.deepEquals(map1, map2));
         assertEquals(DeepEquals.deepHashCode(map1), DeepEquals.deepHashCode(map2));


### PR DESCRIPTION
Some Map implementation (e.g. https://github.com/real-logic/agrona/blob/master/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java) use single Map.Entry instance to minimize garbage

`DeepEquals::compareUnorderedMap` at the moment does not deal with them very well - when building `fastLookup` same instance is cached N times, so after the loop lookup table contains last element of the iterator N times!

This PR addresses the problem by creating shallow clone  of the entry. Which obviously have some performance implications - however I guess DeepEquals is mostly used in tests, or at very least outside of critical path.