### PR TITLE
improved comparing of classnames when BlackListing specific ones

### DIFF
--- a/src/main/java/com/cedarsoftware/util/DeepEquals.java
+++ b/src/main/java/com/cedarsoftware/util/DeepEquals.java
@@ -173,7 +173,7 @@ public class DeepEquals
 
     private static boolean deepEquals(Object a, Object b, Map<?, ?> options, Set<ItemsToCompare> visited) {
         Deque<ItemsToCompare> stack = new LinkedList<>();
-        Set<String> ignoreCustomEquals = (Set<String>) options.get(IGNORE_CUSTOM_EQUALS);
+        Set<Class<?>> ignoreCustomEquals = (Set<Class<?>>) options.get(IGNORE_CUSTOM_EQUALS);
         final boolean allowStringsToMatchNumbers = convert2boolean(options.get(ALLOW_STRINGS_TO_MATCH_NUMBERS));
 
         stack.addFirst(new ItemsToCompare(a, b));

--- a/src/test/java/com/cedarsoftware/util/TestDeepEquals.java
+++ b/src/test/java/com/cedarsoftware/util/TestDeepEquals.java
@@ -62,12 +62,12 @@ public class TestDeepEquals
         assert deepEquals(p1, p2);
 
         Map<String, Object> options = new HashMap<>();
-        Set<Class> skip = new HashSet<>();
+        Set<Class<?>> skip = new HashSet<>();
         skip.add(Person.class);
         options.put(DeepEquals.IGNORE_CUSTOM_EQUALS, skip);
         assert !deepEquals(p1, p2, options);       // told to skip Person's .equals() - so it will compare all fields
 
-        options.put(DeepEquals.IGNORE_CUSTOM_EQUALS, new HashSet());
+        options.put(DeepEquals.IGNORE_CUSTOM_EQUALS, new HashSet<>());
         assert !deepEquals(p1, p2, options);       // told to skip all custom .equals() - so it will compare all fields
 
         skip.clear();


### PR DESCRIPTION
#69 fixed possible incorrect casting Set<Class> -> Set<String>. Now the ignoreCustomEquals is expected to be Set<Class<?>>.