### PR TITLE
Fixed IllegalAccessException on DeepEquals for Atomic Booleans, and f…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,11 @@
         <version.logback>1.4.11</version.logback>
         <version.junit>5.10.0</version.junit>
         <version.json.io>4.14.1</version.json.io>           <!-- testing only -->
-        <version.mockito>1.10.19</version.mockito>          <!-- testing only -->
+        <version.mockito>5.6.0</version.mockito>          <!-- testing only -->
+        <version.mockito.inline>5.2.0</version.mockito.inline>          <!-- testing only -->
         <version.agrona>1.19.2</version.agrona>              <!-- testing only -->
+        <version.mockito.inline>5.2.0</version.mockito.inline>          <!-- testing only -->
+        <version.assertj>3.24.2</version.assertj>              <!-- testing only -->
         <version.plugin.compiler>3.11.0</version.plugin.compiler>
         <version.plugin.gpg>3.1.0</version.plugin.gpg>
         <version.plugin.javadoc>3.6.0</version.plugin.javadoc>
@@ -213,10 +216,32 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${version.mockito.inline}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${version.mockito.inline}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>com.cedarsoftware</groupId>

--- a/src/main/java/com/cedarsoftware/util/DeepEquals.java
+++ b/src/main/java/com/cedarsoftware/util/DeepEquals.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.cedarsoftware.util.Converter.convert2BigDecimal;
 import static com.cedarsoftware.util.Converter.convert2boolean;
@@ -209,6 +210,15 @@ public class DeepEquals
             if (key1 instanceof Number && key2 instanceof Number && compareNumbers((Number)key1, (Number)key2))
             {
                 continue;
+            }
+
+            if (key1 instanceof AtomicBoolean && key2 instanceof AtomicBoolean)
+            {
+                if (!compareAtomicBoolean((AtomicBoolean)key1, (AtomicBoolean)key2)) {
+                    return false;
+                } else {
+                    continue;
+                }
             }
 
             if (key1 instanceof Number || key2 instanceof Number)
@@ -593,7 +603,11 @@ public class DeepEquals
         }
         return false;
     }
-    
+
+    private static boolean compareAtomicBoolean(AtomicBoolean a, AtomicBoolean b) {
+        return a.get() == b.get();
+    }
+
     private static boolean compareNumbers(Number a, Number b)
     {
         if (a instanceof Float && (b instanceof Float || b instanceof Double))

--- a/src/test/java/com/cedarsoftware/util/TestReflectionUtils.java
+++ b/src/test/java/com/cedarsoftware/util/TestReflectionUtils.java
@@ -12,7 +12,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -187,20 +190,11 @@ public class TestReflectionUtils
     @Test
     public void testGetDeclaredFields() throws Exception
     {
-        Class<?> c = Parent.class;
+        var fields = mock(ArrayList.class);
+        when(fields.add(any())).thenThrow(ThreadDeath.class);
 
-        Field f = c.getDeclaredField("foo");
-
-        Collection<Field> fields = mock(Collection.class);
-        when(fields.add(f)).thenThrow(new ThreadDeath());
-        try
-        {
-            ReflectionUtils.getDeclaredFields(Parent.class, fields);
-            fail("should not make it here");
-        }
-        catch (ThreadDeath ignored)
-        {
-        }
+        assertThatExceptionOfType(ThreadDeath.class)
+                .isThrownBy(() -> ReflectionUtils.getDeclaredFields(Parent.class, fields));
     }
 
     @Test


### PR DESCRIPTION
* DeepEquals on Java (11?, 17) was throwing an exception of IllegalAccessException trying to get the volatile field boolean value through reflection (Field access).  Added check for Atomic Boolean type and handle comparison appropriately.
* Fixed mock test for throwing ThreadDeath
