### PR TITLE
Make deepHashCode unique depending on order

### DIFF
--- a/src/main/java/com/cedarsoftware/util/DeepEquals.java
+++ b/src/main/java/com/cedarsoftware/util/DeepEquals.java
@@ -739,7 +739,7 @@ public class DeepEquals
         Set<Object> visited = new HashSet<>();
         LinkedList<Object> stack = new LinkedList<>();
         stack.addFirst(obj);
-        int hash = 0;
+        int hash = 1;
 
         while (!stack.isEmpty())
         {
@@ -784,7 +784,7 @@ public class DeepEquals
 
             if (hasCustomHashCode(obj.getClass()))
             {   // A real hashCode() method exists, call it.
-                hash += obj.hashCode();
+                hash = 31 * hash + obj.hashCode();
                 continue;
             }
 


### PR DESCRIPTION
Currently `DeepEquals.deepHashCode()` does not care about order. This means that these two lists will be equal:

![image](https://github.com/jdereg/java-util/assets/43613843/ce449eb4-838a-4984-bd6b-9917129cf3f6)
![image](https://github.com/jdereg/java-util/assets/43613843/64df8880-20c4-4863-9a69-02979ffba4f3)

The proposed changes fix this behaviour, making only truly identically objects match. This is of course a breaking api change.

Thanks for making this awesome library, Cheers!