### PR TITLE
Add module info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <version.maven-source-plugin>3.3.0</version.maven-source-plugin>
         <version.maven-scr-plugin>1.26.4</version.maven-scr-plugin>
         <version.maven-bundle-plugin>5.1.9</version.maven-bundle-plugin>
+        <version.moditect>1.0.0.Final</version.moditect>
 
         <!-- release plugin -->
         <version.nexus-staging-maven-plugin>1.6.13</version.nexus-staging-maven-plugin>
@@ -226,6 +227,37 @@
                 <version>${version.maven-surefire-plugin}</version>
             </plugin>
 
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>${version.moditect}</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>com.cedarsoftware.util</name>
+                                    <requires>
+                                        java.sql;
+                                        java.xml;
+                                    </requires>
+                                    <exports>
+                                        com.cedarsoftware.util;
+                                        com.cedarsoftware.util.convert;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This adds an explicit module-info.class to the final jar under `META-INF/versions/9`. This means that it shouldn't affect compatibility with 8 and lets downstream users bundle their code with jlink