### PR TITLE
Fix testNewArrayElement

### DIFF
--- a/src/test/java/com/cedarsoftware/util/TestGraphComparator.java
+++ b/src/test/java/com/cedarsoftware/util/TestGraphComparator.java
@@ -629,23 +629,31 @@ public class TestGraphComparator
 
         List<GraphComparator.Delta> deltas = GraphComparator.compare(persons[0], persons[1], getIdFetcher());
         assertTrue(deltas.size() == 3);
-        GraphComparator.Delta delta = deltas.get(0);
-        assertTrue(ARRAY_SET_ELEMENT == delta.getCmd());
-        assertTrue("pets".equals(delta.getFieldName()));
-        assertTrue(0 == (Integer) delta.getOptionalKey());
-        assertTrue(persons[1].pets[0].equals(delta.getTargetValue()));
-        assertTrue((Long) delta.getId() == id);
 
-        delta = deltas.get(1);
-        assertTrue(OBJECT_ASSIGN_FIELD == delta.getCmd());
-        assertTrue("favoritePet".equals(delta.getFieldName()));
-        assertTrue(null == delta.getOptionalKey());
-        assertTrue(persons[1].pets[0].equals(delta.getTargetValue()));
-        assertTrue((Long) delta.getId() == id);
+        boolean arraySetElementFound = false;
+        boolean objectAssignFieldFound = false;
+        boolean objectOrphanFound = false;
 
-        delta = deltas.get(2);
-        assertTrue(OBJECT_ORPHAN == delta.getCmd());
-        assertTrue(edId == (Long) delta.getId());
+
+        for (GraphComparator.Delta delta : deltas) {
+            if (ARRAY_SET_ELEMENT == delta.getCmd()) {
+                assertTrue("pets".equals(delta.getFieldName()));
+                assertTrue(0 == (Integer)delta.getOptionalKey());
+                assertTrue(persons[1].pets[0].equals(delta.getTargetValue()));
+                assertTrue(id == (Long) delta.getId());
+                arraySetElementFound = true;
+            } else if (OBJECT_ASSIGN_FIELD == delta.getCmd()) {
+                assertTrue("favoritePet".equals(delta.getFieldName()));
+                assertTrue(delta.getOptionalKey() == null);
+                assertTrue(persons[1].pets[0].equals(delta.getTargetValue()));
+                assertTrue(id == (Long) delta.getId());
+                objectAssignFieldFound = true;
+            } else if (OBJECT_ORPHAN == delta.getCmd()) {
+                assertTrue(edId == (Long) delta.getId());
+                objectOrphanFound = true;
+            }
+        }
+
 
         GraphComparator.applyDelta(persons[0], deltas, getIdFetcher(), GraphComparator.getJavaDeltaProcessor());
         assertTrue(DeepEquals.deepEquals(persons[0], persons[1]));


### PR DESCRIPTION
The `assertTrue(DeepEquals.deepEquals(persons[0], persons[1]));`
within `testNewArrayElement` in `TestGraphComparator.java`, could return `false` instead of expected `true`. 

After investigating within the `GraphComparator` class, specifically the `compare `method that returns a list of Delta objects, the values returned were expected and correct, but in the wrong order.

The original order of the test was:

	1.	First delta (ARRAY_SET_ELEMENT): Changing the element in the pets array (at index 0) to the new pet.
	2.	Second delta (OBJECT_ASSIGN_FIELD): Assigning the new pet to favoritePet.
	3.	Third delta (OBJECT_ORPHAN): Marking the old pet (edId) as orphaned.

The first delta returned was correct, but the second and third deltas returned were the correct values just in opposite order, causing the test to not pass.

To reproduce this problem, you can run the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool with this command: 
```
mvn -pl . edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.cedarsoftware.util.TestGraphComparator#testNewArrayElement
```

This PR proposes a solution to relax the order in assertions. To do so, first set flags for each delta to be found. Then traverse through the list of deltas being compared and updating the flag for each delta as long as it is found.

Please let me know if you’d like to discuss these changes.
