### PR TITLE
fix: find osgi loader

### DIFF
--- a/src/main/java/com/cedarsoftware/util/ClassUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ClassUtilities.java
@@ -411,6 +411,9 @@ public class ClassUtilities
                     // Get the adapt(Class) method
                     Method adaptMethod = bundle.getClass().getMethod("adapt", Class.class);
 
+                    // method is inside not a public class, so we need to make it accessible
+                    adaptMethod.setAccessible(true);
+
                     // Invoke bundle.adapt(BundleWiring.class) to get the BundleWiring instance
                     Object bundleWiring = adaptMethod.invoke(bundle, bundleWiringClass);
 

--- a/src/test/java/com/cedarsoftware/util/TestDateUtilities.java
+++ b/src/test/java/com/cedarsoftware/util/TestDateUtilities.java
@@ -555,8 +555,9 @@ class TestDateUtilities
         boolean okToTest = false;
 
         for (String zoneName : timeZoneOldSchoolNames) {
-            if (dateToString.contains(zoneName)) {
+            if (dateToString.contains(" " + zoneName)) {
                 okToTest = true;
+                break;
             }
         }
 
@@ -874,7 +875,7 @@ class TestDateUtilities
     @Test
     void testTimeBetterThanMilliResolution()
     {
-        ZonedDateTime zonedDateTime = (ZonedDateTime) DateUtilities.parseDate("Jan 22nd, 2024 21:52:05.123456789-05:00", ZoneId.systemDefault(), true);
+        ZonedDateTime zonedDateTime = DateUtilities.parseDate("Jan 22nd, 2024 21:52:05.123456789-05:00", ZoneId.systemDefault(), true);
         assertEquals(123456789, zonedDateTime.getNano());
         assertEquals(2024, zonedDateTime.getYear());
         assertEquals(1, zonedDateTime.getMonthValue());


### PR DESCRIPTION
the previous implementation didn't take into account the method BundleImpl.adapt is inside package-private package and it can't be accessible from ClassUtils.class
Also, java-util bundle ClassLoader has access to only its resources.

Example:
In the case of json-io we want to find the resources in that jar that's why we need to look in its bundle classloader instead. 

Related PRs:
https://github.com/jdereg/json-io/pull/298
https://github.com/jdereg/java-util/pull/108