### PR TITLE
cleaning up warnings

### DIFF
--- a/src/main/java/com/cedarsoftware/util/ClassUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ClassUtilities.java
@@ -147,6 +147,10 @@ import static java.lang.reflect.Modifier.isPublic;
  *         limitations under the License.
  */
 public class ClassUtilities {
+
+    private ClassUtilities() {
+    }
+
     private static final Set<Class<?>> prims = new HashSet<>();
     private static final Map<Class<?>, Class<?>> primitiveToWrapper = new HashMap<>(20, .8f);
     private static final Map<String, Class<?>> nameToClass = new ConcurrentHashMap<>();

--- a/src/main/java/com/cedarsoftware/util/Converter.java
+++ b/src/main/java/com/cedarsoftware/util/Converter.java
@@ -774,6 +774,7 @@ public final class Converter
      * No longer needed - use convert(localDate, long.class)
      * @param localDate A Java LocalDate
      * @return a long representing the localDate as epoch milliseconds (since 1970 Jan 1 at midnight)
+     * @deprecated  replaced by convert(localDate, long.class)
      */
     @Deprecated
     public static long localDateToMillis(LocalDate localDate)
@@ -785,6 +786,7 @@ public final class Converter
      * No longer needed - use convert(localDateTime, long.class)
      * @param localDateTime A Java LocalDateTime
      * @return a long representing the localDateTime as epoch milliseconds (since 1970 Jan 1 at midnight)
+     * @deprecated replaced by convert(localDateTime, long.class)
      */
     @Deprecated
     public static long localDateTimeToMillis(LocalDateTime localDateTime)
@@ -796,6 +798,7 @@ public final class Converter
      * No longer needed - use convert(ZonedDateTime, long.class)
      * @param zonedDateTime A Java ZonedDateTime
      * @return a long representing the ZonedDateTime as epoch milliseconds (since 1970 Jan 1 at midnight)
+     * @deprecated replaced by convert(ZonedDateTime, long.class)
      */
     @Deprecated
     public static long zonedDateTimeToMillis(ZonedDateTime zonedDateTime)

--- a/src/main/java/com/cedarsoftware/util/ReflectionUtils.java
+++ b/src/main/java/com/cedarsoftware/util/ReflectionUtils.java
@@ -360,12 +360,8 @@ public final class ReflectionUtils {
             return false;
         }
 
-        if (declaringClass.isAssignableFrom(Enum.class) &&
-                ("hash".equals(fieldName) || "ordinal".equals(fieldName))) {
-            return false;
-        }
-
-        return true;
+        return !declaringClass.isAssignableFrom(Enum.class) ||
+                (!"hash".equals(fieldName) && !"ordinal".equals(fieldName));
     };
     
     /**

--- a/src/main/java/com/cedarsoftware/util/SafeSimpleDateFormat.java
+++ b/src/main/java/com/cedarsoftware/util/SafeSimpleDateFormat.java
@@ -118,7 +118,7 @@ public class SafeSimpleDateFormat extends DateFormat
     }
 
     public String toString() {
-        return _format.toString();
+        return _format;
     }
 
     @Override

--- a/src/main/java/com/cedarsoftware/util/StringUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/StringUtilities.java
@@ -1,6 +1,8 @@
 package com.cedarsoftware.util;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -115,7 +117,7 @@ import static java.lang.Character.toLowerCase;
  *         limitations under the License.
  */
 public final class StringUtilities {
-    private static char[] _hex = {
+    private static final char[] _hex = {
             '0', '1', '2', '3', '4', '5', '6', '7',
             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
     };
@@ -636,7 +638,7 @@ public final class StringUtilities {
 
     public static String getRandomChar(Random random, boolean upper) {
         int r = random.nextInt(26);
-        return upper ? EMPTY + (char) ((int) 'A' + r) : EMPTY + (char) ((int) 'a' + r);
+        return upper ? EMPTY + (char) ('A' + r) : EMPTY + (char) ('a' + r);
     }
 
     /**
@@ -658,6 +660,8 @@ public final class StringUtilities {
     }
 
 
+    //  TODO: The following two methods are exactly the same other than the case of the method.
+    //  TODO: deprecate one and remove next major version.
     /**
      * Convert a byte[] into a UTF-8 String.  Preferable used when the encoding
      * is one of the guaranteed Java types and you don't want to have to catch
@@ -666,7 +670,16 @@ public final class StringUtilities {
      * @param bytes bytes to encode into a string
      */
     public static String createUtf8String(byte[] bytes) {
-        return createString(bytes, "UTF-8");
+        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Convert a byte[] into a UTF-8 encoded String.
+     *
+     * @param bytes bytes to encode into a string
+     */
+    public static String createUTF8String(byte[] bytes) {
+        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
     }
 
     /**
@@ -675,7 +688,7 @@ public final class StringUtilities {
      * @param s string to encode into bytes
      */
     public static byte[] getUTF8Bytes(String s) {
-        return getBytes(s, "UTF-8");
+        return s == null ? null : s.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -694,15 +707,6 @@ public final class StringUtilities {
         catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException(String.format("Encoding (%s) is not supported by your JVM", encoding), e);
         }
-    }
-
-    /**
-     * Convert a byte[] into a UTF-8 encoded String.
-     *
-     * @param bytes bytes to encode into a string
-     */
-    public static String createUTF8String(byte[] bytes) {
-        return createString(bytes, "UTF-8");
     }
 
     /**

--- a/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
+++ b/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
@@ -178,8 +178,8 @@ public class LockingLRUCacheStrategy<K, V> implements Map<K, V> {
                 cache.put(key, newNode);
                 addToHead(newNode);
                 if (cache.size() > capacity) {
-                    Node<K, V> tail = removeTail();
-                    cache.remove(tail.key);
+                    Node<K, V> tailToRemove = removeTail();
+                    cache.remove(tailToRemove.key);
                 }
                 return null;
             }


### PR DESCRIPTION
* Added @deprecated tags to javadoc
* cleaned up some warnings.
* Added TOTO about two identical methods with different case strings.
* Changed create string from bytes to use CharSet instead of string named encoding (that you have to catch exception)