### PR TITLE
fix: FastWriter missing characters on buffer limit

### DIFF
--- a/src/main/java/com/cedarsoftware/util/FastWriter.java
+++ b/src/main/java/com/cedarsoftware/util/FastWriter.java
@@ -101,6 +101,9 @@ public class FastWriter extends Writer {
         if (nextChar + len <= cb.length) {
             str.getChars(off, off + len, cb, nextChar);
             nextChar += len;
+            if (nextChar == cb.length) {
+                flushBuffer();
+            }
             return;
         }
 

--- a/src/main/java/com/cedarsoftware/util/FastWriter.java
+++ b/src/main/java/com/cedarsoftware/util/FastWriter.java
@@ -110,6 +110,7 @@ public class FastWriter extends Writer {
             str.getChars(off, off + available, cb, nextChar);
             off += available;
             len -= available;
+            nextChar = cb.length;
             flushBuffer();
         }
 

--- a/src/test/java/com/cedarsoftware/util/TestIO.java
+++ b/src/test/java/com/cedarsoftware/util/TestIO.java
@@ -1,5 +1,6 @@
 package com.cedarsoftware.util;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -10,6 +11,8 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class TestIO
 {
@@ -76,6 +79,22 @@ public class TestIO
         out.close();
 
         assert content.equals(new String(baos.toByteArray(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void fastWriterBufferLimitValue() throws IOException {
+        final String line511 = IntStream.range(0, 63).mapToObj(it -> "a").collect(Collectors.joining());
+        final String nextLine = "Tbbb";
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FastWriter out = new FastWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8), 64);
+        out.write(line511);
+        out.write(nextLine);
+        out.close();
+
+        final String actual = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        Assertions.assertEquals(line511+nextLine, actual);
     }
 
     @Test

--- a/src/test/java/com/cedarsoftware/util/TestIO.java
+++ b/src/test/java/com/cedarsoftware/util/TestIO.java
@@ -98,6 +98,22 @@ public class TestIO
     }
 
     @Test
+    void fastWriterBufferSizeIsEqualToLimit() throws IOException {
+        final String line511 = IntStream.range(0, 64).mapToObj(it -> "a").collect(Collectors.joining());
+        final String nextLine = "Tbbb";
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FastWriter out = new FastWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8), 64);
+        out.write(line511);
+        out.write(nextLine);
+        out.close();
+
+        final String actual = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        Assertions.assertEquals(line511+nextLine, actual);
+    }
+
+    @Test
     public void testFastWriterCharBuffer() throws Exception
     {
         String content = TestUtil.fetchResource("prettyPrint.json");


### PR DESCRIPTION
The test should illustrate the problem.
1) Character 'T' was missed, because before `flush` we didn't update the length of the buffer
2) The first line that equals to the buffer size is ignored because `flush` didn't happen