### PR TITLE
Fix zero parsing in MathUtilities

### DIFF
--- a/src/main/java/com/cedarsoftware/util/MathUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/MathUtilities.java
@@ -283,13 +283,14 @@ public final class MathUtilities
      */
     public static Number parseToMinimalNumericType(String numStr) {
         // Handle and preserve negative signs correctly while removing leading zeros
-        boolean isNegative = numStr.startsWith("-");
-        if (isNegative || numStr.startsWith("+")) {
-            char sign = numStr.charAt(0);
-            numStr = sign + numStr.substring(1).replaceFirst("^0+", "");
-        } else {
-            numStr = numStr.replaceFirst("^0+", "");
+        boolean negative = numStr.startsWith("-");
+        boolean hasSign = negative || numStr.startsWith("+");
+        String digits = hasSign ? numStr.substring(1) : numStr;
+        digits = digits.replaceFirst("^0+", "");
+        if (digits.isEmpty()) {
+            digits = "0";
         }
+        numStr = (negative ? "-" : (hasSign ? "+" : "")) + digits;
 
         boolean hasDecimalPoint = false;
         boolean hasExponent = false;

--- a/src/test/java/com/cedarsoftware/util/MathUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/MathUtilitiesTest.java
@@ -291,6 +291,13 @@ class MathUtilitiesTest
     }
 
     @Test
+    void testZeroValues() {
+        assertEquals(0L, parseToMinimalNumericType("0"));
+        assertEquals(0L, parseToMinimalNumericType("-0"));
+        assertEquals(0L, parseToMinimalNumericType("+0"));
+    }
+
+    @Test
     void testBeyondMaxLongBoundary() {
         String beyondMaxLong = "9223372036854775808"; // Long.MAX_VALUE + 1
         assertEquals(new BigInteger("9223372036854775808"), parseToMinimalNumericType(beyondMaxLong));


### PR DESCRIPTION
## Summary
- handle all-zero strings in `parseToMinimalNumericType`
- test parsing of 0, -0 and +0

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*