### PR TITLE
Fix CompactSet for JRE

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactCIHashSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactCIHashSet.java
@@ -38,10 +38,9 @@ public class CompactCIHashSet<E> extends CompactSet<E> {
      * @throws IllegalArgumentException if {@link #compactSize()} returns a value less than 2
      */
     public CompactCIHashSet() {
-        // Initialize the superclass with a pre-configured CompactMap using the builder
-        super(CompactMap.<E, Object>builder()
-                .caseSensitive(false) // case-insensitive
-                .build());
+        super(ReflectionUtils.isJavaCompilerAvailable()
+                ? CompactMap.<E, Object>builder().caseSensitive(false).build()
+                : CompactSet.createSimpleMap(false, CompactMap.DEFAULT_COMPACT_SIZE, CompactMap.UNORDERED));
     }
 
     /**

--- a/src/main/java/com/cedarsoftware/util/CompactCILinkedSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactCILinkedSet.java
@@ -44,11 +44,9 @@ public class CompactCILinkedSet<E> extends CompactSet<E> {
      * @throws IllegalArgumentException if {@link #compactSize()} returns a value less than 2
      */
     public CompactCILinkedSet() {
-        // Initialize the superclass with a pre-configured CompactMap using the builder
-        super(CompactMap.<E, Object>builder()
-                .caseSensitive(false) // case-insensitive
-                .insertionOrder()
-                .build());
+        super(ReflectionUtils.isJavaCompilerAvailable()
+                ? CompactMap.<E, Object>builder().caseSensitive(false).insertionOrder().build()
+                : CompactSet.createSimpleMap(false, CompactMap.DEFAULT_COMPACT_SIZE, CompactMap.INSERTION));
     }
 
     /**

--- a/src/main/java/com/cedarsoftware/util/CompactLinkedSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactLinkedSet.java
@@ -43,11 +43,9 @@ public class CompactLinkedSet<E> extends CompactSet<E> {
      * @throws IllegalArgumentException if {@link #compactSize()} returns a value less than 2
      */
     public CompactLinkedSet() {
-        // Initialize the superclass with a pre-configured CompactMap using the builder
-        super(CompactMap.<E, Object>builder()
-                .caseSensitive(true)
-                .insertionOrder()
-                .build());
+        super(ReflectionUtils.isJavaCompilerAvailable()
+                ? CompactMap.<E, Object>builder().caseSensitive(true).insertionOrder().build()
+                : CompactSet.createSimpleMap(true, CompactMap.DEFAULT_COMPACT_SIZE, CompactMap.INSERTION));
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid builder usage in `CompactSet` when Java compiler is unavailable
- store builder options and build fallback map implementations
- add `createSimpleMap` helper to construct fallback maps
- update specialized `Compact*Set` classes to work without builder

## Testing
- `javac -cp src/main/java -d /tmp/out $(grep -rl "package" src/main/java/com/cedarsoftware/util | tr '\n' ' ')`
- `echo "Tests skipped"`