### PR TITLE
Fix typo in MapUtilities Javadoc

### DIFF
--- a/src/main/java/com/cedarsoftware/util/MapUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/MapUtilities.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.SortedMap;
 
 /**
- * Usefule utilities for Maps
+ * Useful utilities for Maps
  *
  * @author Ken Partlow (kpartlow@gmail.com)
  * @author John DeRegnaucourt (jdereg@gmail.com)


### PR DESCRIPTION
## Summary
- fix a typo in the MapUtilities Javadoc comment

## Testing
- `mvn -v` *(fails: command not found)*