### PR TITLE
Fix digest fallback in encryption utilities

### DIFF
--- a/src/main/java/com/cedarsoftware/util/EncryptionUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/EncryptionUtilities.java
@@ -210,7 +210,7 @@ public class EncryptionUtilities {
                 return calculateFileHash(((FileInputStream) in).getChannel(), getSHA256Digest());
             }
             // Fallback for non-file input streams (rare, but possible with custom filesystem providers)
-            return calculateStreamHash(in, getSHA1Digest());
+            return calculateStreamHash(in, getSHA256Digest());
         } catch (NoSuchFileException e) {
             return null;
         } catch (IOException e) {
@@ -237,7 +237,7 @@ public class EncryptionUtilities {
                 return calculateFileHash(((FileInputStream) in).getChannel(), getSHA512Digest());
             }
             // Fallback for non-file input streams (rare, but possible with custom filesystem providers)
-            return calculateStreamHash(in, getSHA1Digest());
+            return calculateStreamHash(in, getSHA512Digest());
         } catch (NoSuchFileException e) {
             return null;
         } catch (IOException e) {


### PR DESCRIPTION
## Summary
- ensure fastSHA256 and fastSHA512 use matching digests for fallback streams

## Testing
- `mvn -q test` *(fails: `mvn` not found)*