### PR TITLE
Fix CompactSet ordering when JRE simulated

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -628,10 +628,7 @@ public class CompactMap<K, V> implements Map<K, V> {
 
             // Only sort if it's a SortedMap
             if (mapInstance instanceof SortedMap) {
-                SortedMap<K,V> sortedMap = (SortedMap<K,V>)mapInstance;
-                boolean reverse = sortedMap.comparator() != null &&
-                        sortedMap.comparator().getClass().getName().toLowerCase().contains("reversecomp");
-
+                boolean reverse = REVERSE.equals(getOrdering());
                 Comparator<Object> comparator = new CompactMapComparator(isCaseInsensitive(), reverse);
                 quickSort(array, 0, pairCount - 1, comparator);
             }

--- a/src/main/java/com/cedarsoftware/util/ReflectionUtils.java
+++ b/src/main/java/com/cedarsoftware/util/ReflectionUtils.java
@@ -1580,10 +1580,14 @@ public final class ReflectionUtils {
      * Returns true if the JavaCompiler (JDK) is available at runtime, false if running under a JRE.
      */
     public static boolean isJavaCompilerAvailable() {
+        // Allow tests to simulate running on a JRE by setting a system property.
+        if (Boolean.getBoolean("java.util.force.jre")) {
+            return false;
+        }
+
         try {
             Class<?> toolProvider = Class.forName("javax.tools.ToolProvider");
             Object compiler = toolProvider.getMethod("getSystemJavaCompiler").invoke(null);
-//            return false;
             return compiler != null;
         } catch (Throwable t) {
             return false;


### PR DESCRIPTION
## Summary
- allow simulating a JRE by setting `java.util.force.jre`
- correct ordering detection when CompactMap is built without templates

## Testing
- `javac -d /tmp/classes @/tmp/sources.txt`
