### PR TITLE
Add JDK requirement notes for CompactMap builder APIs

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -1507,7 +1507,14 @@ public class CompactMap<K, V> implements Map<K, V> {
     /**
      * Creates a new CompactMap with the same entries but different configuration.
      * <p>
-     * This is useful for creating a new CompactMap with the same configuration as another compactMap.
+     * This is useful for creating a new CompactMap with the same configuration
+     * as another compactMap.
+     *
+     * <p><b>JDK Requirement:</b> this method ultimately calls
+     * {@link Builder#build()} which generates a specialized subclass using the
+     * JDK compiler. It will throw an {@link IllegalStateException} when executed
+     * in a runtime that lacks these compiler tools (such as a JRE-only
+     * container).
      *
      * @param config a map containing configuration options to change
      * @return a new CompactMap with the specified configuration and the same entries
@@ -1798,6 +1805,13 @@ public class CompactMap<K, V> implements Map<K, V> {
      * @return a new CompactMap instance configured according to options
      * @throws IllegalArgumentException if options are invalid or incompatible
      * @throws IllegalStateException if template generation or instantiation fails
+     *         and the Java compiler tools are not present (for example when only
+     *         a JRE is available)
+     *
+     * <p><b>JDK Requirement:</b> this method generates specialized subclasses at
+     * runtime using the JDK compiler. Running in an environment without
+     * {@code javax.tools.JavaCompiler} will result in an
+     * {@link IllegalStateException}.</p>
      */
     static <K, V> CompactMap<K, V> newMap(Map<String, Object> options) {
         // Ensure JDK Java Compiler is available before proceeding
@@ -2290,16 +2304,10 @@ public class CompactMap<K, V> implements Map<K, V> {
          * based on the configuration. The resulting map is optimized for the
          * specified combination of options.
          *
-         * @return a new CompactMap instance
-         * @throws IllegalArgumentException if any configuration options are invalid
-         *         or incompatible
-         */
-        /**
-         * Creates a new CompactMap instance with the configured options.
-         * <p>
-         * This method validates all options and creates a specialized implementation
-         * based on the configuration. The resulting map is optimized for the
-         * specified combination of options.
+         * <p><b>JDK Requirement:</b> this method generates a specialized subclass
+         * at runtime using {@code javax.tools.JavaCompiler}. It will throw an
+         * {@link IllegalStateException} when the compiler tools are not present
+         * (for example in a JRE-only environment).
          *
          * @return a new CompactMap instance
          * @throws IllegalStateException if JavaCompiler is unavailable at runtime (JRE detected)

--- a/userguide.md
+++ b/userguide.md
@@ -465,6 +465,15 @@ CompactMap<String, Object> ordered = CompactMap.<String, Object>builder()
     .build();
 ```
 
+> **JDK Requirement**
+> 
+> The `build()`, `newMap()`, and `withConfig()` APIs dynamically generate a
+> specialized subclass using the JDK compiler. These methods will throw an
+> `IllegalStateException` when the compiler tools are unavailable (for example
+> in JRE-only container environments). In those cases, either use the default
+> constructor or one of the pre-built classes such as `CompactLinkedMap`,
+> `CompactCIHashMap`, or `CompactCILinkedMap`.
+
 **Configuration Options:**
 ```java
 // Comprehensive configuration


### PR DESCRIPTION
## Summary
- document that `build()`, `newMap()` and `withConfig()` need JDK compiler
- add warning in user guide about JDK requirement

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*