### PR TITLE
Update CompactSet docs with JDK warning

### DIFF
--- a/userguide.md
+++ b/userguide.md
@@ -33,6 +33,15 @@ CompactSet<String> ordered = CompactSet.<String>builder()
     .build();
 ```
 
+> **JDK Requirement**
+>
+> The `build()` and `withConfig()` APIs dynamically generate a
+> specialized subclass using the JDK compiler. These methods will throw an
+> `IllegalStateException` when the compiler tools are unavailable (for example
+> in JRE-only container environments). In those cases, either use the default
+> constructor or one of the pre-built classes such as `CompactLinkedSet`,
+> `CompactCIHashSet`, or `CompactCILinkedSet`.
+
 ### Configuration Options
 
 #### Case Sensitivity


### PR DESCRIPTION
## Summary
- add JDK/JRE requirement warning to the CompactSet section

## Testing
- `mvn -q test` *(fails: `mvn` not found)*