### PR TITLE
Fix CaseInsensitiveMap tests

### DIFF
--- a/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapTest.java
@@ -63,6 +63,9 @@ class CaseInsensitiveMapTest
     public void cleanup() {
         // Reset to default for other tests
         CaseInsensitiveMap.setMaxCacheLengthString(100);
+        // Restore the default CaseInsensitiveString cache to avoid
+        // interference between tests that modify the global cache.
+        CaseInsensitiveMap.replaceCache(new LRUCache<>(5000, LRUCache.StrategyType.THREADED));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reset default cache in `CaseInsensitiveMapTest.cleanup`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*