### PR TITLE
Add Javadoc to uncovered classes and methods

### DIFF
--- a/src/main/java/com/cedarsoftware/util/Convention.java
+++ b/src/main/java/com/cedarsoftware/util/Convention.java
@@ -2,6 +2,13 @@ package com.cedarsoftware.util;
 
 import java.util.Map;
 
+/**
+ * Utility class containing common defensive programming helpers.
+ * <p>
+ * {@code Convention} offers a set of static convenience methods for
+ * validating method arguments such as null checks or ensuring that a
+ * string is not empty.  The class is not intended to be instantiated.
+ */
 public class Convention {
 
     /**

--- a/src/main/java/com/cedarsoftware/util/GraphComparator.java
+++ b/src/main/java/com/cedarsoftware/util/GraphComparator.java
@@ -53,11 +53,26 @@ public class GraphComparator
 {
     public static final String ROOT = "-root-";
 
+    /**
+     * Callback used to obtain a unique identifier for a given object during
+     * graph comparison.
+     */
     public interface ID
     {
+        /**
+         * Return the identifier to use for the supplied object.
+         *
+         * @param objectToId object from which to obtain an id
+         * @return unique identifier for the object
+         */
         Object getId(Object objectToId);
     }
 
+    /**
+     * Represents a single difference between two object graphs.  A collection
+     * of {@code Delta} instances can be used to transform one graph so that it
+     * matches another.
+     */
     public static class Delta implements Serializable
     {
         private static final long serialVersionUID = -4388236892818050806L;
@@ -69,6 +84,16 @@ public class GraphComparator
         private Object optionalKey;
         private Command cmd;
 
+        /**
+         * Construct a delta describing a change between two graphs.
+         *
+         * @param id          identifier of the object containing the difference
+         * @param fieldName   name of the field that differs
+         * @param srcPtr      pointer within the source graph
+         * @param srcValue    value from the source graph
+         * @param targetValue value from the target graph
+         * @param optKey      optional key used by certain collection operations
+         */
         public Delta(Object id, String fieldName, String srcPtr, Object srcValue, Object targetValue, Object optKey)
         {
             this.id = id;
@@ -79,16 +104,25 @@ public class GraphComparator
             optionalKey = optKey;
         }
 
+        /**
+         * @return identifier of the object containing the change
+         */
         public Object getId()
         {
             return id;
         }
 
+        /**
+         * Update the identifier associated with this delta.
+         */
         public void setId(Object id)
         {
             this.id = id;
         }
 
+        /**
+         * @return the name of the field where the difference occurred
+         */
         public String getFieldName()
         {
             return fieldName;
@@ -99,6 +133,9 @@ public class GraphComparator
             this.fieldName = fieldName;
         }
 
+        /**
+         * @return value from the source graph
+         */
         public Object getSourceValue()
         {
             return srcValue;
@@ -109,6 +146,9 @@ public class GraphComparator
             this.srcValue = srcValue;
         }
 
+        /**
+         * @return value from the target graph
+         */
         public Object getTargetValue()
         {
             return targetValue;
@@ -119,6 +159,9 @@ public class GraphComparator
             this.targetValue = targetValue;
         }
 
+        /**
+         * @return optional key used for collection operations
+         */
         public Object getOptionalKey()
         {
             return optionalKey;
@@ -129,6 +172,9 @@ public class GraphComparator
             this.optionalKey = optionalKey;
         }
 
+        /**
+         * @return command describing the modification type
+         */
         public Command getCmd()
         {
             return cmd;
@@ -222,17 +268,30 @@ public class GraphComparator
         }
     }
 
+    /**
+     * Extension of {@link Delta} that associates an error message with the
+     * delta that failed to be applied.
+     */
     public static class DeltaError extends Delta
     {
         private static final long serialVersionUID = 6248596026486571238L;
         public String error;
 
+        /**
+         * Construct a delta error.
+         *
+         * @param error message describing the problem
+         * @param delta the delta that failed
+         */
         public DeltaError(String error, Delta delta)
         {
             super(delta.getId(), delta.fieldName, delta.srcPtr, delta.srcValue, delta.targetValue, delta.optionalKey);
             this.error = error;
         }
 
+        /**
+         * @return the error message
+         */
         public String getError()
         {
             return error;
@@ -244,18 +303,43 @@ public class GraphComparator
         }
     }
 
+    /**
+     * Strategy interface used when applying {@link Delta} objects to a source
+     * graph.  Implementations perform the actual mutation operations.
+     */
     public interface DeltaProcessor
     {
+        /** Apply a value into an array element. */
         void processArraySetElement(Object srcValue, Field field, Delta delta);
+
+        /** Resize an array to match the target length. */
         void processArrayResize(Object srcValue, Field field, Delta delta);
+
+        /** Assign a field value on an object. */
         void processObjectAssignField(Object srcValue, Field field, Delta delta);
+
+        /** Remove an orphaned object from the graph. */
         void processObjectOrphan(Object srcValue, Field field, Delta delta);
+
+        /** Change the type of an object reference. */
         void processObjectTypeChanged(Object srcValue, Field field, Delta delta);
+
+        /** Add a value to a {@link java.util.Set}. */
         void processSetAdd(Object srcValue, Field field, Delta delta);
+
+        /** Remove a value from a {@link java.util.Set}. */
         void processSetRemove(Object srcValue, Field field, Delta delta);
+
+        /** Put a key/value pair into a {@link java.util.Map}. */
         void processMapPut(Object srcValue, Field field, Delta delta);
+
+        /** Remove an entry from a {@link java.util.Map}. */
         void processMapRemove(Object srcValue, Field field, Delta delta);
+
+        /** Adjust a {@link java.util.List}'s size. */
         void processListResize(Object srcValue, Field field, Delta delta);
+
+        /** Set a list element to a new value. */
         void processListSetElement(Object srcValue, Field field, Delta delta);
 
         class Helper

--- a/src/main/java/com/cedarsoftware/util/StreamGobbler.java
+++ b/src/main/java/com/cedarsoftware/util/StreamGobbler.java
@@ -35,11 +35,20 @@ public class StreamGobbler implements Runnable
         _inputStream = is;
     }
 
+    /**
+     * Returns all text that was read from the underlying input stream.
+     *
+     * @return captured output from the stream
+     */
     public String getResult()
     {
         return _result;
     }
 
+    /**
+     * Continuously reads from the supplied input stream until it is exhausted.
+     * The collected data is stored so it can be retrieved via {@link #getResult()}.
+     */
     public void run()
     {
         InputStreamReader isr = null;

--- a/src/main/java/com/cedarsoftware/util/SystemUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/SystemUtilities.java
@@ -237,79 +237,142 @@ public final class SystemUtilities
     }
 
     // Support classes
+
+    /**
+     * Simple container class describing the JVM memory usage at a given point
+     * in time.
+     */
     public static class MemoryInfo {
         private final long totalMemory;
         private final long freeMemory;
         private final long maxMemory;
 
+        /**
+         * Create an instance holding the supplied memory metrics.
+         *
+         * @param totalMemory total memory currently allocated to the JVM
+         * @param freeMemory  amount of memory that is unused
+         * @param maxMemory   maximum memory the JVM will attempt to use
+         */
         public MemoryInfo(long totalMemory, long freeMemory, long maxMemory) {
             this.totalMemory = totalMemory;
             this.freeMemory = freeMemory;
             this.maxMemory = maxMemory;
         }
 
+        /**
+         * @return the total memory currently allocated to the JVM
+         */
         public long getTotalMemory() {
             return totalMemory;
         }
 
+        /**
+         * @return the amount of unused memory
+         */
         public long getFreeMemory() {
             return freeMemory;
         }
 
+        /**
+         * @return the maximum memory the JVM can utilize
+         */
         public long getMaxMemory() {
             return maxMemory;
         }
     }
 
+    /**
+     * Describes a network interface present on the host system.
+     */
     public static class NetworkInfo {
         private final String name;
         private final String displayName;
         private final List<InetAddress> addresses;
         private final boolean loopback;
 
+        /**
+         * Construct a new {@code NetworkInfo} instance.
+         *
+         * @param name        the interface name
+         * @param displayName the human readable display name
+         * @param addresses   all addresses bound to the interface
+         * @param loopback    whether this interface represents the loopback device
+         */
         public NetworkInfo(String name, String displayName, List<InetAddress> addresses, boolean loopback) {
             this.name = name;
             this.displayName = displayName;
             this.addresses = addresses;
             this.loopback = loopback;
         }
-        
+
+        /**
+         * @return the interface name
+         */
         public String getName() {
             return name;
         }
 
+        /**
+         * @return the user friendly display name
+         */
         public String getDisplayName() {
             return displayName;
         }
 
+        /**
+         * @return all addresses associated with the interface
+         */
         public List<InetAddress> getAddresses() {
             return addresses;
         }
 
+        /**
+         * @return {@code true} if this interface is a loopback interface
+         */
         public boolean isLoopback() {
             return loopback;
         }
     }
 
+    /**
+     * Captures the results of executing an operating system process.
+     */
     public static class ProcessResult {
         private final int exitCode;
         private final String output;
         private final String error;
 
+        /**
+         * Create a new result.
+         *
+         * @param exitCode the exit value returned by the process
+         * @param output   text captured from standard out
+         * @param error    text captured from standard error
+         */
         public ProcessResult(int exitCode, String output, String error) {
             this.exitCode = exitCode;
             this.output = output;
             this.error = error;
         }
 
+        /**
+         * @return the exit value of the process
+         */
         public int getExitCode() {
             return exitCode;
         }
 
+        /**
+         * @return the contents of the standard output stream
+         */
         public String getOutput() {
             return output;
         }
 
+        /**
+         * @return the contents of the standard error stream
+         */
         public String getError() {
             return error;
         }

--- a/src/main/java/com/cedarsoftware/util/TTLCache.java
+++ b/src/main/java/com/cedarsoftware/util/TTLCache.java
@@ -254,6 +254,10 @@ public class TTLCache<K, V> implements Map<K, V> {
 
     // Implementations of Map interface methods
 
+    /**
+     * Associates the specified value with the specified key in this cache.
+     * The entry will expire after the configured TTL has elapsed.
+     */
     @Override
     public V put(K key, V value) {
         long expiryTime = System.currentTimeMillis() + ttlMillis;
@@ -284,6 +288,10 @@ public class TTLCache<K, V> implements Map<K, V> {
         return oldEntry != null ? oldEntry.node.value : null;
     }
 
+    /**
+     * Returns the value to which the specified key is mapped, or {@code null}
+     * if this cache contains no mapping for the key or if the entry has expired.
+     */
     @Override
     public V get(Object key) {
         CacheEntry<K, V> entry = cacheMap.get(key);
@@ -314,6 +322,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         return value;
     }
 
+    /**
+     * Removes the mapping for a key from this cache if it is present.
+     */
     @Override
     public V remove(Object key) {
         CacheEntry<K, V> entry = cacheMap.remove(key);
@@ -330,6 +341,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         return null;
     }
 
+    /**
+     * Removes all of the mappings from this cache.
+     */
     @Override
     public void clear() {
         cacheMap.clear();
@@ -343,16 +357,26 @@ public class TTLCache<K, V> implements Map<K, V> {
         }
     }
 
+    /**
+     * @return the number of entries currently stored
+     */
     @Override
     public int size() {
         return cacheMap.size();
     }
 
+    /**
+     * @return {@code true} if this cache contains no key-value mappings
+     */
     @Override
     public boolean isEmpty() {
         return cacheMap.isEmpty();
     }
 
+    /**
+     * Returns {@code true} if this cache contains a mapping for the specified key
+     * and it has not expired.
+     */
     @Override
     public boolean containsKey(Object key) {
         CacheEntry<K, V> entry = cacheMap.get(key);
@@ -366,6 +390,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         return true;
     }
 
+    /**
+     * Returns {@code true} if this cache maps one or more keys to the specified value.
+     */
     @Override
     public boolean containsValue(Object value) {
         for (CacheEntry<K, V> entry : cacheMap.values()) {
@@ -377,6 +404,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         return false;
     }
 
+    /**
+     * Copies all of the mappings from the specified map to this cache.
+     */
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
         for (Entry<? extends K, ? extends V> e : m.entrySet()) {
@@ -384,6 +414,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         }
     }
 
+    /**
+     * @return a {@link Set} view of the keys contained in this cache
+     */
     @Override
     public Set<K> keySet() {
         Set<K> keys = new HashSet<>();
@@ -394,6 +427,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         return keys;
     }
 
+    /**
+     * @return a {@link Collection} view of the values contained in this cache
+     */
     @Override
     public Collection<V> values() {
         List<V> values = new ArrayList<>();
@@ -404,6 +440,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         return values;
     }
 
+    /**
+     * @return a {@link Set} view of the mappings contained in this cache
+     */
     @Override
     public Set<Entry<K, V>> entrySet() {
         return new EntrySet();
@@ -464,6 +503,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         }
     }
 
+    /**
+     * Compares the specified object with this cache for equality.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -479,6 +521,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         }
     }
 
+    /**
+     * Returns the hash code value for this cache.
+     */
     @Override
     public int hashCode() {
         lock.lock();
@@ -496,6 +541,9 @@ public class TTLCache<K, V> implements Map<K, V> {
         }
     }
 
+    /**
+     * Returns a string representation of this cache.
+     */
     @Override
     public String toString() {
         lock.lock();


### PR DESCRIPTION
## Summary
- document `Convention` class
- add JavaDocs for support classes in `SystemUtilities`
- document getters in `StreamGobbler`
- add JavaDocs for map methods in `TTLCache`
- document `GraphComparator` helper interfaces and classes

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*