### PR TITLE
Add null check for CaseInsensitiveMap cache replacement

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CaseInsensitiveMap.java
+++ b/src/main/java/com/cedarsoftware/util/CaseInsensitiveMap.java
@@ -210,6 +210,7 @@ public class CaseInsensitiveMap<K, V> extends AbstractMap<K, V> {
      */
     @SuppressWarnings("unchecked, rawtypes")
     public static void replaceCache(LRUCache lruCache) {
+        Objects.requireNonNull(lruCache, "Cache cannot be null");
         CaseInsensitiveString.COMMON_STRINGS = lruCache;
     }
 

--- a/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapTest.java
@@ -2522,6 +2522,11 @@ void testComputeIfAbsent() {
     }
 
     @Test
+    public void testReplaceCacheWithNull() {
+        assertThrows(NullPointerException.class, () -> CaseInsensitiveMap.replaceCache(null));
+    }
+
+    @Test
     public void testStringCachingBasedOnLength() {
         // Test string shorter than max length (should be cached)
         CaseInsensitiveMap.setMaxCacheLengthString(10);


### PR DESCRIPTION
## Summary
- validate the new cache in `CaseInsensitiveMap.replaceCache`
- test that `replaceCache(null)` throws `NullPointerException`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dfa27c5ec832a9ac8a3a02e93582c