### PR TITLE
Add null checks for map constructor

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CaseInsensitiveMap.java
+++ b/src/main/java/com/cedarsoftware/util/CaseInsensitiveMap.java
@@ -297,6 +297,11 @@ public class CaseInsensitiveMap<K, V> extends AbstractMap<K, V> {
      * @throws IllegalArgumentException if mapInstance is not empty
      */
     public CaseInsensitiveMap(Map<K, V> source, Map<K, V> mapInstance) {
+        Objects.requireNonNull(source, "source map cannot be null");
+        Objects.requireNonNull(mapInstance, "mapInstance cannot be null");
+        if (!mapInstance.isEmpty()) {
+            throw new IllegalArgumentException("mapInstance must be empty");
+        }
         map = copy(source, mapInstance);
     }
 

--- a/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapConstructorTest.java
+++ b/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapConstructorTest.java
@@ -1,0 +1,30 @@
+package com.cedarsoftware.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CaseInsensitiveMapConstructorTest {
+
+    @Test
+    void testNullSourceMap() {
+        assertThrows(NullPointerException.class, () -> new CaseInsensitiveMap<>(null, new HashMap<>()));
+    }
+
+    @Test
+    void testNullMapInstance() {
+        Map<String, String> source = new HashMap<>();
+        assertThrows(NullPointerException.class, () -> new CaseInsensitiveMap<>(source, null));
+    }
+
+    @Test
+    void testNonEmptyMapInstance() {
+        Map<String, String> source = new HashMap<>();
+        Map<String, String> dest = new HashMap<>();
+        dest.put("one", "1");
+        assertThrows(IllegalArgumentException.class, () -> new CaseInsensitiveMap<>(source, dest));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce null and empty checks in `CaseInsensitiveMap(Map, Map)`
- cover constructor edge cases with unit tests

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dfa313ce4832ab47dbbb297422cdc