### PR TITLE
Fix case-insensitive typo in Javadoc

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CaseInsensitiveMap.java
+++ b/src/main/java/com/cedarsoftware/util/CaseInsensitiveMap.java
@@ -877,7 +877,7 @@ public class CaseInsensitiveMap<K, V> extends AbstractMap<K, V> {
     }
 
     /**
-     * Wrapper class for String keys to enforce case-ireplnsensitive comparison.
+     * Wrapper class for String keys to enforce case-insensitive comparison.
      * Implements CharSequence for compatibility with String operations and
      * Serializable for persistence support.
      */


### PR DESCRIPTION
## Summary
- fix typo in `CaseInsensitiveMap` Javadoc for `CaseInsensitiveString`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dfa3876f8832aa99d5b30325381f4