### PR TITLE
Fix CompactMap putAll javadoc

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -1014,8 +1014,9 @@ public class CompactMap<K, V> implements Map<K, V> {
     /**
      * Copies all mappings from the specified map into this map.
      * <p>
-     * If resulting size would exceed compactSize, transitions directly to map storage.
-     * Otherwise, adds entries individually, allowing natural transitions to occur.
+     * Entries are inserted one by one using {@link #put(Object, Object)},
+     * allowing the map to transition naturally through its storage modes
+     * as elements are added.
      * </p>
      *
      * @param map mappings to be stored in this map

--- a/src/test/java/com/cedarsoftware/util/CompactMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactMapTest.java
@@ -686,6 +686,28 @@ public class CompactMapTest
     }
 
     @Test
+    public void testPutAllExceedCompactSize() {
+        CompactMap<String, Object> map = new CompactMap<>() {
+            protected String getSingleValueKey() { return "value"; }
+            protected int compactSize() { return 3; }
+            protected Map<String, Object> getNewMap() { return new LinkedHashMap<>(); }
+        };
+
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("a", 1);
+        source.put("b", 2);
+        source.put("c", 3);
+        source.put("d", 4);
+
+        map.putAll(source);
+
+        assertEquals(4, map.size());
+        assertTrue(map.val instanceof Map);
+        assertEquals(1, map.get("a"));
+        assertEquals(4, map.get("d"));
+    }
+
+    @Test
     public void testClear()
     {
         Map<String, Object> map= new CompactMap()


### PR DESCRIPTION
## Summary
- update `CompactMap.putAll` javadoc to describe actual behavior
- add test covering `putAll` when exceeding compact size

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dfe3f1624832a89ba33461e0e61f5