### PR TITLE
Enforce whitelist for CompactMap mapType

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -109,7 +110,9 @@ import java.util.stream.Collectors;
  *   </tr>
  *   <tr>
  *     <td>{@code mapType(Class)}</td>
- *     <td>Type of backing map when size exceeds compact size</td>
+ *     <td>Type of backing map when size exceeds compact size (must originate
+ *         from {@code java.util.*}, {@code java.util.concurrent.*}, or
+ *         {@code com.cedarsoftware.util.*})</td>
  *     <td>HashMap.class</td>
  *   </tr>
  *   <tr>
@@ -257,9 +260,26 @@ public class CompactMap<K, V> implements Map<K, V> {
     public static final boolean DEFAULT_CASE_SENSITIVE = true;
     public static final Class<? extends Map> DEFAULT_MAP_TYPE = HashMap.class;
     public static final String DEFAULT_SINGLE_KEY = "id";
+    /**
+     * Packages allowed when specifying a custom backing map type.
+     */
+    private static final Set<String> ALLOWED_MAP_PACKAGES = new HashSet<>(Arrays.asList(
+            "java.util",
+            "java.util.concurrent",
+            "com.cedarsoftware.util"));
     private static final String INNER_MAP_TYPE = "innerMapType";
     private static final TemplateClassLoader templateClassLoader = new TemplateClassLoader(ClassUtilities.getClassLoader(CompactMap.class));
     private static final Map<String, ReentrantLock> CLASS_LOCKS = new ConcurrentHashMap<>();
+
+    private static boolean isAllowedMapType(Class<?> mapType) {
+        String name = mapType.getName();
+        for (String prefix : ALLOWED_MAP_PACKAGES) {
+            if (name.startsWith(prefix + ".") || name.equals(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     // The only "state" and why this is a compactMap - one-member variable
     protected Object val = EMPTY_MAP;
@@ -1984,6 +2004,7 @@ public class CompactMap<K, V> implements Map<K, V> {
      *           <li>source map's ordering conflicts with requested ordering</li>
      *           <li>IdentityHashMap or WeakHashMap is specified as map type</li>
      *           <li>specified map type is not a Map class</li>
+     *           <li>map type comes from a disallowed package</li>
      *         </ul>
      * @see #COMPACT_SIZE
      * @see #CASE_SENSITIVE
@@ -2001,6 +2022,10 @@ public class CompactMap<K, V> implements Map<K, V> {
         }
 
         Class<? extends Map> mapType = determineMapType(options, ordering);
+        if (!isAllowedMapType(mapType)) {
+            throw new IllegalArgumentException("Map type " + mapType.getName() +
+                    " is not from an allowed package");
+        }
         boolean caseSensitive = (boolean) options.getOrDefault(CASE_SENSITIVE, DEFAULT_CASE_SENSITIVE);
 
         // Store the validated mapType
@@ -2295,14 +2320,22 @@ public class CompactMap<K, V> implements Map<K, V> {
          *     <li>{@link LinkedHashMap} - Insertion order</li>
          * </ul>
          * Note: {@link IdentityHashMap} and {@link WeakHashMap} are not supported.
+         * The map type must come from an allowed package
+         * ({@code java.util.*}, {@code java.util.concurrent.*}, or
+         * {@code com.cedarsoftware.util.*}).
          *
          * @param mapType the Class object representing the desired Map implementation
          * @return this builder instance for method chaining
-         * @throws IllegalArgumentException if mapType is not a Map class
+         * @throws IllegalArgumentException if mapType is not a Map class or is
+         *         from a disallowed package
          */
         public Builder<K, V> mapType(Class<? extends Map> mapType) {
             if (!Map.class.isAssignableFrom(mapType)) {
                 throw new IllegalArgumentException("mapType must be a Map class");
+            }
+            if (!isAllowedMapType(mapType)) {
+                throw new IllegalArgumentException("Map type " + mapType.getName() +
+                        " is not from an allowed package");
             }
             options.put(MAP_TYPE, mapType);
             return this;

--- a/src/test/java/com/bad/UnapprovedMap.java
+++ b/src/test/java/com/bad/UnapprovedMap.java
@@ -1,0 +1,6 @@
+package com.bad;
+
+import java.util.HashMap;
+
+public class UnapprovedMap<K,V> extends HashMap<K,V> {
+}

--- a/src/test/java/com/cedarsoftware/util/CompactMapBuilderConfigTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactMapBuilderConfigTest.java
@@ -254,6 +254,30 @@ public class CompactMapBuilderConfigTest {
     }
 
     @Test
+    public void testMapTypeFromDisallowedPackageRejected() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                CompactMap.builder()
+                        .mapType(com.bad.UnapprovedMap.class)
+                        .build()
+        );
+
+        assertEquals("Map type com.bad.UnapprovedMap is not from an allowed package",
+                exception.getMessage());
+    }
+
+    @Test
+    public void testValidateOptionsRejectsDisallowedPackage() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(CompactMap.MAP_TYPE, com.bad.UnapprovedMap.class);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> CompactMap.validateAndFinalizeOptions(options));
+
+        assertEquals("Map type com.bad.UnapprovedMap is not from an allowed package",
+                exception.getMessage());
+    }
+
+    @Test
     public void testReverseOrderWithCaseInsensitiveStrings() {
         CompactMap<String, String> map = CompactMap.<String, String>builder()
                 .caseSensitive(false)  // Enable case-insensitive mode


### PR DESCRIPTION
## Summary
- enforce allowed packages when choosing a `mapType`
- update builder docs and Javadoc with new requirement
- add `UnapprovedMap` test helper
- verify invalid map types are rejected

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684dfe34c46c832a8058d793928c5c49