### PR TITLE
Improve putAll efficiency

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -1025,6 +1025,29 @@ public class CompactMap<K, V> implements Map<K, V> {
         if (map == null || map.isEmpty()) {
             return;
         }
+
+        int targetSize = size() + map.size();
+
+        if (targetSize > compactSize()) {
+            Map<K, V> backingMap;
+            if (val instanceof Map) {
+                backingMap = (Map<K, V>) val;
+            } else {
+                backingMap = getNewMap();
+                if (val instanceof Object[]) {   // Existing compact array
+                    Object[] entries = (Object[]) val;
+                    for (int i = 0; i < entries.length; i += 2) {
+                        backingMap.put((K) entries[i], (V) entries[i + 1]);
+                    }
+                } else if (val != EMPTY_MAP) {   // Single entry state
+                    backingMap.put(getLogicalSingleKey(), getLogicalSingleValue());
+                }
+                val = backingMap;
+            }
+            backingMap.putAll(map);
+            return;
+        }
+
         for (Entry<? extends K, ? extends V> entry : map.entrySet()) {
             put(entry.getKey(), entry.getValue());
         }

--- a/src/test/java/com/cedarsoftware/util/CompactMapPutAllTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactMapPutAllTest.java
@@ -1,0 +1,54 @@
+package com.cedarsoftware.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CompactMapPutAllTest {
+    private static final int TEST_COMPACT_SIZE = 3;
+
+    @Test
+    public void testPutAllSwitchesToMapWhenThresholdExceeded() {
+        CompactMap<String, String> map = new CompactMap<String, String>() {
+            protected int compactSize() { return TEST_COMPACT_SIZE; }
+            protected Map<String, String> getNewMap() { return new LinkedHashMap<>(); }
+        };
+
+        map.put("A", "alpha");
+        map.put("B", "bravo");
+
+        Map<String, String> extra = new LinkedHashMap<>();
+        extra.put("C", "charlie");
+        extra.put("D", "delta");
+
+        map.putAll(extra);
+
+        assertEquals(4, map.size());
+        assertEquals(CompactMap.LogicalValueType.MAP, map.getLogicalValueType());
+        assertEquals("alpha", map.get("A"));
+        assertEquals("delta", map.get("D"));
+    }
+
+    @Test
+    public void testPutAllStaysArrayWhenWithinThreshold() {
+        CompactMap<String, String> map = new CompactMap<String, String>() {
+            protected int compactSize() { return TEST_COMPACT_SIZE; }
+            protected Map<String, String> getNewMap() { return new LinkedHashMap<>(); }
+        };
+
+        map.put("A", "alpha");
+        map.put("B", "bravo");
+
+        Map<String, String> extra = new LinkedHashMap<>();
+        extra.put("C", "charlie");
+
+        map.putAll(extra);
+
+        assertEquals(3, map.size());
+        assertEquals(CompactMap.LogicalValueType.ARRAY, map.getLogicalValueType());
+        assertEquals("charlie", map.get("C"));
+    }
+}


### PR DESCRIPTION
## Summary
- detect large bulk inserts in CompactMap.putAll
- copy existing entries directly to a backing map
- add regression tests ensuring putAll switches representation when exceeding the threshold

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684dfe1a0a5c832a92f0720ed80566f3