### PR TITLE
Manage compiler resources

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -2893,44 +2893,44 @@ public class CompactMap<K, V> implements Map<K, V> {
             }
 
             DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-            StandardJavaFileManager stdFileManager = compiler.getStandardFileManager(diagnostics, null, null);
-
-            // Create in-memory source file
-            SimpleJavaFileObject sourceFile = new SimpleJavaFileObject(
-                    URI.create("string:///" + className.replace('.', '/') + ".java"),
-                    JavaFileObject.Kind.SOURCE) {
-                @Override
-                public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                    return sourceCode;
-                }
-            };
-
-            // Create in-memory output for class file
             Map<String, ByteArrayOutputStream> classOutputs = new HashMap<>();
-            JavaFileManager fileManager = new ForwardingJavaFileManager(stdFileManager) {
-                @Override
-                public JavaFileObject getJavaFileForOutput(Location location,
-                                                           String className,
-                                                           JavaFileObject.Kind kind,
-                                                           FileObject sibling) throws IOException {
-                    if (kind == JavaFileObject.Kind.CLASS) {
-                        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                        classOutputs.put(className, outputStream);
-                        return new SimpleJavaFileObject(
-                                URI.create("byte:///" + className.replace('.', '/') + ".class"),
-                                JavaFileObject.Kind.CLASS) {
-                            @Override
-                            public OutputStream openOutputStream() {
-                                return outputStream;
-                            }
-                        };
-                    }
-                    return super.getJavaFileForOutput(location, className, kind, sibling);
-                }
-            };
 
-            // Compile the source
-            JavaCompiler.CompilationTask task = compiler.getTask(
+            // Manage file managers with try-with-resources
+            try (StandardJavaFileManager stdFileManager = compiler.getStandardFileManager(diagnostics, null, null);
+                 JavaFileManager fileManager = new ForwardingJavaFileManager(stdFileManager) {
+                     @Override
+                     public JavaFileObject getJavaFileForOutput(Location location,
+                                                                String className,
+                                                                JavaFileObject.Kind kind,
+                                                                FileObject sibling) throws IOException {
+                         if (kind == JavaFileObject.Kind.CLASS) {
+                             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                             classOutputs.put(className, outputStream);
+                             return new SimpleJavaFileObject(
+                                     URI.create("byte:///" + className.replace('.', '/') + ".class"),
+                                     JavaFileObject.Kind.CLASS) {
+                                 @Override
+                                 public OutputStream openOutputStream() {
+                                     return outputStream;
+                                 }
+                             };
+                         }
+                         return super.getJavaFileForOutput(location, className, kind, sibling);
+                     }
+                 }) {
+
+                // Create in-memory source file
+                SimpleJavaFileObject sourceFile = new SimpleJavaFileObject(
+                        URI.create("string:///" + className.replace('.', '/') + ".java"),
+                        JavaFileObject.Kind.SOURCE) {
+                    @Override
+                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return sourceCode;
+                    }
+                };
+
+                // Compile the source
+                JavaCompiler.CompilationTask task = compiler.getTask(
                     null,                // Writer for compiler messages
                     fileManager,         // Custom file manager
                     diagnostics,         // DiagnosticListener
@@ -2956,6 +2956,11 @@ public class CompactMap<K, V> implements Map<K, V> {
 
             // Define the class
             byte[] classBytes = classOutput.toByteArray();
+            classOutput.close();
+            // Ensure any additional class streams are closed
+            for (ByteArrayOutputStream baos : classOutputs.values()) {
+                baos.close();
+            }
             return defineClass(className, classBytes);
         }
 

--- a/src/test/java/com/cedarsoftware/util/CompileClassResourceTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompileClassResourceTest.java
@@ -1,0 +1,92 @@
+package com.cedarsoftware.util;
+
+import javax.tools.*;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+
+public class CompileClassResourceTest {
+    static class TrackingJavaCompiler implements JavaCompiler {
+        private final JavaCompiler delegate;
+        final AtomicBoolean closed = new AtomicBoolean(false);
+
+        TrackingJavaCompiler(JavaCompiler delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public CompilationTask getTask(Writer out, JavaFileManager fileManager,
+                                       DiagnosticListener<? super JavaFileObject> diagnosticListener,
+                                       Iterable<String> options, Iterable<String> classes,
+                                       Iterable<? extends JavaFileObject> compilationUnits) {
+            return delegate.getTask(out, fileManager, diagnosticListener, options, classes, compilationUnits);
+        }
+
+        @Override
+        public StandardJavaFileManager getStandardFileManager(DiagnosticListener<? super JavaFileObject> dl,
+                                                              Locale locale, Charset charset) {
+            StandardJavaFileManager fm = delegate.getStandardFileManager(dl, locale, charset);
+            return new ForwardingJavaFileManager<>(fm) {
+                @Override
+                public void close() throws IOException {
+                    closed.set(true);
+                    super.close();
+                }
+            };
+        }
+
+        @Override
+        public int run(InputStream in, OutputStream out, OutputStream err, String... arguments) {
+            return delegate.run(in, out, err, arguments);
+        }
+
+        @Override
+        public Set<SourceVersion> getSourceVersions() {
+            return delegate.getSourceVersions();
+        }
+
+        @Override
+        public int isSupportedOption(String option) {
+            return delegate.isSupportedOption(option);
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+    }
+
+    @Test
+    public void testFileManagerClosed() throws Exception {
+        JavaCompiler real = ToolProvider.getSystemJavaCompiler();
+        TrackingJavaCompiler tracking = new TrackingJavaCompiler(real);
+        try (MockedStatic<ToolProvider> mocked = mockStatic(ToolProvider.class)) {
+            mocked.when(ToolProvider::getSystemJavaCompiler).thenReturn(tracking);
+
+            Class<?> tmplGen = null;
+            for (Class<?> cls : CompactMap.class.getDeclaredClasses()) {
+                if (cls.getSimpleName().equals("TemplateGenerator")) {
+                    tmplGen = cls;
+                    break;
+                }
+            }
+            assertNotNull(tmplGen);
+
+            Method compile = tmplGen.getDeclaredMethod("compileClass", String.class, String.class);
+            compile.setAccessible(true);
+            String src = "package com.cedarsoftware.util; public class Tmp {}";
+            Object clsObj = compile.invoke(null, "com.cedarsoftware.util.Tmp", src);
+            assertNotNull(clsObj);
+        }
+        assertTrue(tracking.closed.get(), "FileManager should be closed");
+    }
+}


### PR DESCRIPTION
## Summary
- use try-with-resources when compiling template classes
- ensure ByteArrayOutputStreams and file managers are closed
- add unit test verifying compiler resources are released

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684dfdf8fb60832aa30901afc7da0d02