### PR TITLE
Fix Java 8 compatibility

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -2954,7 +2954,7 @@ public class CompactMap<K, V> implements Map<K, V> {
 
             // Manage file managers with try-with-resources
             try (StandardJavaFileManager stdFileManager = compiler.getStandardFileManager(diagnostics, null, null);
-                 JavaFileManager fileManager = new ForwardingJavaFileManager(stdFileManager) {
+                 JavaFileManager fileManager = new ForwardingJavaFileManager<StandardJavaFileManager>(stdFileManager) {
                      @Override
                      public JavaFileObject getJavaFileForOutput(Location location,
                                                                 String className,


### PR DESCRIPTION
## Summary
- update CompactMap compilation utility for Java 8 compatibility

## Testing
- `javac --release 8 -d /tmp/classes $(find src/main/java -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_684e032f7abc832a9efc2737d882910e