### PR TITLE
Fix Java 8 compatibility

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -2954,7 +2954,7 @@ public class CompactMap<K, V> implements Map<K, V> {
 
             // Manage file managers with try-with-resources
             try (StandardJavaFileManager stdFileManager = compiler.getStandardFileManager(diagnostics, null, null);
-                 JavaFileManager fileManager = new ForwardingJavaFileManager(stdFileManager) {
+                 JavaFileManager fileManager = new ForwardingJavaFileManager<StandardJavaFileManager>(stdFileManager) {
                      @Override
                      public JavaFileObject getJavaFileForOutput(Location location,
                                                                 String className,
@@ -3019,7 +3019,11 @@ public class CompactMap<K, V> implements Map<K, V> {
                 baos.close();
             }
             return defineClass(className, classBytes);
+        } // end try-with-resources
+        catch (IOException e) {
+            throw new IllegalStateException("I/O error during compilation", e);
         }
+    } // close compileClass()
 
         /**
          * Defines a Class object from compiled bytecode using a custom ClassLoader.


### PR DESCRIPTION
## Summary
- update CompactMap compilation utility for Java 8 compatibility

## Testing
- `javac --release 8 -d /tmp/classes @sources.txt`
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e032f7abc832a9efc2737d882910e