### PR TITLE
Fix JDK 8 compilation for tests

### DIFF
--- a/src/test/java/com/cedarsoftware/util/CompileClassResourceTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompileClassResourceTest.java
@@ -35,7 +35,7 @@ public class CompileClassResourceTest {
         public StandardJavaFileManager getStandardFileManager(DiagnosticListener<? super JavaFileObject> dl,
                                                               Locale locale, Charset charset) {
             StandardJavaFileManager fm = delegate.getStandardFileManager(dl, locale, charset);
-            return new ForwardingJavaFileManager<>(fm) {
+            return new ForwardingJavaFileManager<StandardJavaFileManager>(fm) {
                 @Override
                 public void close() throws IOException {
                     closed.set(true);
@@ -59,10 +59,6 @@ public class CompileClassResourceTest {
             return delegate.isSupportedOption(option);
         }
 
-        @Override
-        public String name() {
-            return delegate.name();
-        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update anonymous class generic syntax
- remove overriding method not present in JDK 8

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e0c7628c4832a8b86681719a07c39