### PR TITLE
Simplify CaseInsensitiveSet remove/retain

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CaseInsensitiveSet.java
+++ b/src/main/java/com/cedarsoftware/util/CaseInsensitiveSet.java
@@ -399,23 +399,7 @@ public class CaseInsensitiveSet<E> implements Set<E> {
      * @throws NullPointerException if the specified collection is {@code null}
      */
     public boolean retainAll(Collection<?> c) {
-        Map<E, Object> other = new CaseInsensitiveMap<>();
-        for (Object o : c) {
-            @SuppressWarnings("unchecked")
-            E element = (E) o; // Safe cast because Map allows adding any type
-            other.put(element, PRESENT);
-        }
-
-        Iterator<E> iterator = map.keySet().iterator();
-        boolean modified = false;
-        while (iterator.hasNext()) {
-            E elem = iterator.next();
-            if (!other.containsKey(elem)) {
-                iterator.remove();
-                modified = true;
-            }
-        }
-        return modified;
+        return map.keySet().retainAll(c);
     }
 
     /**
@@ -432,15 +416,7 @@ public class CaseInsensitiveSet<E> implements Set<E> {
      * @throws NullPointerException if the specified collection is {@code null}
      */
     public boolean removeAll(Collection<?> c) {
-        boolean modified = false;
-        for (Object elem : c) {
-            @SuppressWarnings("unchecked")
-            E element = (E) elem; // Cast to E since map keys match the generic type
-            if (map.remove(element) != null) {
-                modified = true;
-            }
-        }
-        return modified;
+        return map.keySet().removeAll(c);
     }
 
     /**


### PR DESCRIPTION
## Summary
- delegate retainAll/removeAll to underlying CaseInsensitiveMap keySet
- remove temporary CaseInsensitiveMap creation

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e0a7cecdc832a87ed10b1ec433dc3