### PR TITLE
Restrict CaseInsensitiveSet constructor to CI map

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CaseInsensitiveSet.java
+++ b/src/main/java/com/cedarsoftware/util/CaseInsensitiveSet.java
@@ -149,12 +149,12 @@ public class CaseInsensitiveSet<E> implements Set<E> {
      * </p>
      *
      * @param source      the collection whose elements are to be placed into this set
-     * @param backingMap  the map to be used as the backing implementation
+     * @param backingMap  the case-insensitive map to be used as the backing implementation
      * @throws NullPointerException if the specified collection or map is {@code null}
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public CaseInsensitiveSet(Collection<? extends E> source, Map backingMap) {
-        map = backingMap;
+    @SuppressWarnings("unchecked")
+    public CaseInsensitiveSet(Collection<? extends E> source, CaseInsensitiveMap<E, ?> backingMap) {
+        map = (Map<E, Object>) backingMap;
         addAll(source);
     }
 


### PR DESCRIPTION
## Summary
- require `CaseInsensitiveMap` for CaseInsensitiveSet's map-backed constructor
- update javadoc to clarify requirement

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e0a79fa7c832aaa5aaf2ff356acdf