### PR TITLE
Add Serializable support to ConcurrentSet

### DIFF
--- a/src/main/java/com/cedarsoftware/util/ConcurrentSet.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentSet.java
@@ -1,6 +1,7 @@
 package com.cedarsoftware.util;
 
 import java.lang.reflect.Array;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -26,7 +27,9 @@ import java.util.concurrent.ConcurrentHashMap;
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
-public class ConcurrentSet<T> implements Set<T> {
+public class ConcurrentSet<T> implements Set<T>, Serializable {
+    private static final long serialVersionUID = 1L;
+
     private enum NullSentinel {
         NULL_ITEM
     }

--- a/src/test/java/com/cedarsoftware/util/ConcurrentSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentSetTest.java
@@ -1,5 +1,9 @@
 package com.cedarsoftware.util;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -270,5 +275,23 @@ class ConcurrentSetTest {
         latch.await();
         assertTrue(set.size() >= 0 && set.size() <= operationsPerThread,
                 "Set size should be between 0 and " + operationsPerThread);
+    }
+
+    @Test
+    void testSerializationRoundTrip() throws Exception {
+        ConcurrentSet<String> set = new ConcurrentSet<>();
+        set.add("hello");
+        set.add(null);
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bout);
+        out.writeObject(set);
+        out.close();
+
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bout.toByteArray()));
+        ConcurrentSet<String> copy = (ConcurrentSet<String>) in.readObject();
+
+        assertEquals(set, copy);
+        assertNotSame(set, copy);
     }
 }


### PR DESCRIPTION
## Summary
- make `ConcurrentSet` implement `Serializable`
- add `serialVersionUID`
- test serialization round trip in `ConcurrentSetTest`

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e09e98080832a88626943bff2b64d