### PR TITLE
Fix CompactSet review notes

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactCIHashSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactCIHashSet.java
@@ -67,9 +67,4 @@ public class CompactCIHashSet<E> extends CompactSet<E> {
         return true;
     }
 
-    @Override
-    protected Set<E> getNewSet() {
-        // Returning null to indicate it has no effect.
-        return null;
-    }
 }

--- a/src/main/java/com/cedarsoftware/util/CompactCILinkedSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactCILinkedSet.java
@@ -74,9 +74,4 @@ public class CompactCILinkedSet<E> extends CompactSet<E> {
         return true;
     }
 
-    @Override
-    protected Set<E> getNewSet() {
-        // Returning null to indicate it has no effect.
-        return null;
-    }
 }

--- a/src/main/java/com/cedarsoftware/util/CompactLinkedSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactLinkedSet.java
@@ -72,9 +72,4 @@ public class CompactLinkedSet<E> extends CompactSet<E> {
         return true;
     }
 
-    @Override
-    protected Set<E> getNewSet() {
-        // Returning null to indicate it has no effect.
-        return null;
-    }
 }

--- a/src/main/java/com/cedarsoftware/util/CompactSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactSet.java
@@ -125,28 +125,8 @@ public class CompactSet<E> implements Set<E> {
     }
 
     public boolean isDefaultCompactSet() {
-        // 1. Check that compactSize() matches the library default (50)
-        if (map.compactSize() != CompactMap.DEFAULT_COMPACT_SIZE) {
-            return false;
-        }
-
-        // 2. Check that the set is case-sensitive, meaning isCaseInsensitive() should be false.
-        if (map.isCaseInsensitive()) {
-            return false;
-        }
-
-        // 3. Check that the ordering is "unordered"
-        if (!"unordered".equals(map.getOrdering())) {
-            return false;
-        }
-
-        // 4. Check that the single key is "id"
-        if (!CompactMap.DEFAULT_SINGLE_KEY.equals(map.getSingleValueKey())) {
-            return false;
-        }
-        
-        // 5. Check that the backing map is a HashMap.
-        return HashMap.class.equals(map.getNewMap().getClass());
+        // Delegate to the underlying map since the logic is identical
+        return map.isDefaultCompactMap();
     }
     
     /* ----------------------------------------------------------------- */
@@ -363,14 +343,6 @@ public class CompactSet<E> implements Set<E> {
      */
     protected boolean isCaseInsensitive() {
         return false;  // default to case-sensitive, for legacy
-    }
-
-    /**
-     * Allow concrete subclasses to specify the internal set to use when larger than compactSize.  Concrete
-     * subclasses are useful to simplify serialization.
-     */
-    protected Set<E> getNewSet() {
-        return null;
     }
 
     /**

--- a/src/test/java/com/cedarsoftware/util/CompactSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactSetTest.java
@@ -119,7 +119,7 @@ class CompactSetTest
     }
 
     @Test
-    void testHeterogeneuousItems()
+    void testHeterogeneousItems()
     {
         CompactSet<Object> set = new CompactSet<>();
         assert set.add(16);
@@ -212,7 +212,6 @@ class CompactSetTest
         CompactSet<String> set = new CompactSet<String>()
         {
             protected boolean isCaseInsensitive() { return true; }
-            protected Set<String> getNewSet() { return new CaseInsensitiveSet<>(); }
         };
 
         set.add("foo");
@@ -256,7 +255,6 @@ class CompactSetTest
         CompactSet<String> set = new CompactSet<String>()
         {
             protected boolean isCaseInsensitive() { return true; }
-            protected Set<String> getNewSet() { return new CaseInsensitiveSet<>(); }
         };
 
         for (int i=0; i < set.compactSize() + 5; i++)


### PR DESCRIPTION
## Summary
- delegate `CompactSet.isDefaultCompactSet()` to the underlying map
- remove unused `getNewSet()` hook and related overrides
- fix spelling error `testHeterogeneousItems`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e08ad0138832ab4f7de346f2296de