### PR TITLE
Fix headSet/tailSet views in ConcurrentNavigableSetNullSafe

### DIFF
--- a/src/main/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafe.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafe.java
@@ -257,13 +257,13 @@ public class ConcurrentNavigableSetNullSafe<E> extends AbstractSet<E> implements
     @Override
     public NavigableSet<E> headSet(E toElement, boolean inclusive) {
         NavigableSet<Object> headInternal = internalSet.headSet(maskNull(toElement), inclusive);
-        return new ConcurrentNavigableSetNullSafe<>((Collection<E>)headInternal, originalComparator);
+        return new ConcurrentNavigableSetNullSafe<>(headInternal, originalComparator);
     }
 
     @Override
     public NavigableSet<E> tailSet(E fromElement, boolean inclusive) {
         NavigableSet<Object> tailInternal = internalSet.tailSet(maskNull(fromElement), inclusive);
-        return new ConcurrentNavigableSetNullSafe<>((Collection<E>)tailInternal, originalComparator);
+        return new ConcurrentNavigableSetNullSafe<>(tailInternal, originalComparator);
     }
 
     @Override

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
@@ -289,6 +289,45 @@ class ConcurrentNavigableSetNullSafeTest {
     }
 
     @Test
+    void testHeadSetViewModification() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add("date");
+
+        NavigableSet<String> head = set.headSet("cherry", true);
+        head.remove("banana");
+        assertFalse(set.contains("banana"));
+
+        head.add("blueberry");
+        assertTrue(set.contains("blueberry"));
+
+        set.remove("apple");
+        assertFalse(head.contains("apple"));
+    }
+
+    @Test
+    void testTailSetViewModification() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add("date");
+        set.add("elderberry");
+
+        NavigableSet<String> tail = set.tailSet("cherry", true);
+        tail.remove("date");
+        assertFalse(set.contains("date"));
+
+        tail.add("fig");
+        assertTrue(set.contains("fig"));
+
+        set.remove("cherry");
+        assertFalse(tail.contains("cherry"));
+    }
+
+    @Test
     void testIteratorRemove() {
         NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
         set.add("apple");

--- a/userguide.md
+++ b/userguide.md
@@ -311,6 +311,10 @@ SortedSet<Integer> head = set.headSet(4);      // Contains 1, 3
 SortedSet<Integer> tail = set.tailSet(5);      // Contains 5, 7, null
 ```
 
+The `subSet`, `headSet`, and `tailSet` methods return live views backed by the
+original set. Changes made through these views immediately affect the backing
+set and vice versa.
+
 **Descending Views:**
 ```java
 NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();


### PR DESCRIPTION
## Summary
- fix headSet and tailSet to return live views using the private constructor
- add tests verifying that headSet and tailSet views are backed by the original set
- document that subSet/headSet/tailSet return live views

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e0a0a420c832a8e0533bb25305d98