### PR TITLE
Add view modification tests for concurrent navigable set

### DIFF
--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
@@ -289,6 +289,41 @@ class ConcurrentNavigableSetNullSafeTest {
     }
 
     @Test
+    void testHeadAndTailSetViewModification() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add("date");
+        set.add(null);
+
+        NavigableSet<String> headSet = set.headSet("date", false);
+        NavigableSet<String> tailSet = set.tailSet("banana", true);
+
+        // Modify via headSet
+        headSet.remove("banana");
+        headSet.add("aardvark");
+        assertFalse(set.contains("banana"));
+        assertTrue(set.contains("aardvark"));
+
+        // Modify via tailSet
+        tailSet.remove(null);
+        tailSet.add("elderberry");
+        assertFalse(set.contains(null));
+        assertTrue(set.contains("elderberry"));
+
+        // Modify main set
+        set.add("fig");
+        set.remove("apple");
+        assertFalse(headSet.contains("apple"));
+        assertTrue(tailSet.contains("fig"));
+
+        set.remove("cherry");
+        assertFalse(headSet.contains("cherry"));
+        assertFalse(tailSet.contains("cherry"));
+    }
+
+    @Test
     void testIteratorRemove() {
         NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
         set.add("apple");


### PR DESCRIPTION
## Summary
- add a new test to `ConcurrentNavigableSetNullSafeTest` checking that `headSet` and `tailSet` behave as views

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e0a15cb64832abe796d7f6ae04494