### PR TITLE
Add capacity validation to LRUCache constructors

### DIFF
--- a/src/main/java/com/cedarsoftware/util/LRUCache.java
+++ b/src/main/java/com/cedarsoftware/util/LRUCache.java
@@ -66,6 +66,9 @@ public class LRUCache<K, V> implements Map<K, V> {
      * @see com.cedarsoftware.util.cache.LockingLRUCacheStrategy
      */
     public LRUCache(int capacity) {
+        if (capacity < 1) {
+            throw new IllegalArgumentException("Capacity must be at least 1.");
+        }
         strategy = new LockingLRUCacheStrategy<>(capacity);
     }
 
@@ -80,6 +83,9 @@ public class LRUCache<K, V> implements Map<K, V> {
      * @see com.cedarsoftware.util.cache.ThreadedLRUCacheStrategy
      */
     public LRUCache(int capacity, StrategyType strategyType) {
+        if (capacity < 1) {
+            throw new IllegalArgumentException("Capacity must be at least 1.");
+        }
         if (strategyType == StrategyType.THREADED) {
             strategy = new ThreadedLRUCacheStrategy<>(capacity, 10);
         } else if (strategyType == StrategyType.LOCKING) {
@@ -101,6 +107,9 @@ public class LRUCache<K, V> implements Map<K, V> {
      * @see com.cedarsoftware.util.cache.ThreadedLRUCacheStrategy
      */
     public LRUCache(int capacity, int cleanupDelayMillis) {
+        if (capacity < 1) {
+            throw new IllegalArgumentException("Capacity must be at least 1.");
+        }
         strategy = new ThreadedLRUCacheStrategy<>(capacity, cleanupDelayMillis);
     }
 

--- a/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
+++ b/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
@@ -61,9 +61,12 @@ public class LockingLRUCacheStrategy<K, V> implements Map<K, V> {
      * Constructs a new LRU cache with the specified maximum capacity.
      *
      * @param capacity the maximum number of entries the cache can hold
-     * @throws IllegalArgumentException if capacity is negative
+     * @throws IllegalArgumentException if capacity is less than 1
      */
     public LockingLRUCacheStrategy(int capacity) {
+        if (capacity < 1) {
+            throw new IllegalArgumentException("Capacity must be at least 1.");
+        }
         this.capacity = capacity;
         this.cache = new ConcurrentHashMapNullSafe<>(capacity);
         this.head = new Node<>(null, null);

--- a/src/test/java/com/cedarsoftware/util/LRUCacheTest.java
+++ b/src/test/java/com/cedarsoftware/util/LRUCacheTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LRUCacheTest {
@@ -34,6 +35,20 @@ public class LRUCacheTest {
 
     void setUp(LRUCache.StrategyType strategyType) {
         lruCache = new LRUCache<>(3, strategyType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategies")
+    void testInvalidCapacityThrows(LRUCache.StrategyType strategy) {
+        assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(0, strategy));
+        assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(-5, strategy));
+        if (strategy == LRUCache.StrategyType.THREADED) {
+            assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(0, 10));
+            assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(-1, 10));
+        } else {
+            assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(0));
+            assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(-1));
+        }
     }
     
     @ParameterizedTest


### PR DESCRIPTION
## Summary
- validate capacity in `LockingLRUCacheStrategy` constructor
- ensure `LRUCache` constructors reject invalid capacities
- test for invalid capacities

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e29e5dca4832a95ec97710ad9ea9e