### PR TITLE
Fix LRU cache put return value

### DIFF
--- a/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
+++ b/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
@@ -177,9 +177,10 @@ public class LockingLRUCacheStrategy<K, V> implements Map<K, V> {
         try {
             Node<K, V> node = cache.get(key);
             if (node != null) {
+                V oldValue = node.value;
                 node.value = value;
                 moveToHead(node);
-                return node.value;
+                return oldValue;
             } else {
                 Node<K, V> newNode = new Node<>(key, value);
                 cache.put(key, newNode);


### PR DESCRIPTION
## Summary
- adjust `LockingLRUCacheStrategy.put` to return the previous value

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e29e6bb00832a9cb40c88e6b4f409