### PR TITLE
Clarify snapshot semantics for cache views

### DIFF
--- a/src/main/java/com/cedarsoftware/util/TTLCache.java
+++ b/src/main/java/com/cedarsoftware/util/TTLCache.java
@@ -415,7 +415,12 @@ public class TTLCache<K, V> implements Map<K, V> {
     }
 
     /**
-     * @return a {@link Set} view of the keys contained in this cache
+     * Returns the keys currently held in the cache.
+     * <p>
+     * The returned set is a snapshot and is not backed by the cache. Changes to
+     * the set or its iterator do not modify the cache contents.
+     *
+     * @return a snapshot {@link Set} of the keys contained in this cache
      */
     @Override
     public Set<K> keySet() {
@@ -428,7 +433,12 @@ public class TTLCache<K, V> implements Map<K, V> {
     }
 
     /**
-     * @return a {@link Collection} view of the values contained in this cache
+     * Returns the values currently held in the cache.
+     * <p>
+     * Like {@link #keySet()}, this collection is a snapshot.  Mutating the
+     * returned collection or its iterator will not affect the cache.
+     *
+     * @return a snapshot {@link Collection} of the values contained in this cache
      */
     @Override
     public Collection<V> values() {

--- a/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
+++ b/src/main/java/com/cedarsoftware/util/cache/LockingLRUCacheStrategy.java
@@ -305,10 +305,14 @@ public class LockingLRUCacheStrategy<K, V> implements Map<K, V> {
 
     /**
      * Returns a Set view of the mappings contained in this cache.
-     * The set is backed by a new LinkedHashMap to maintain the LRU order.
+     * <p>
+     * The returned set is a <em>snapshot</em> of the cache contents at the time
+     * of the call.  Modifying the set or its iterator does not affect the
+     * underlying cache.  Iterator removal operates only on the snapshot.
+     * The snapshot preserves LRU ordering via a temporary {@link LinkedHashMap}.
      * This operation requires a full traversal under a lock.
      *
-     * @return a set view of the mappings contained in this cache
+     * @return a snapshot set of the mappings contained in this cache
      */
     @Override
     public Set<Map.Entry<K, V>> entrySet() {
@@ -326,10 +330,13 @@ public class LockingLRUCacheStrategy<K, V> implements Map<K, V> {
 
     /**
      * Returns a Set view of the keys contained in this cache.
-     * The set maintains the LRU order of the cache.
+     * <p>
+     * Like {@link #entrySet()}, this method returns a snapshot.  The set is
+     * independent of the cache and retains the current LRU ordering.  Removing
+     * elements from the returned set does not remove them from the cache.
      * This operation requires a full traversal under a lock.
      *
-     * @return a set view of the keys contained in this cache
+     * @return a snapshot set of the keys contained in this cache
      */
     @Override
     public Set<K> keySet() {
@@ -347,10 +354,13 @@ public class LockingLRUCacheStrategy<K, V> implements Map<K, V> {
 
     /**
      * Returns a Collection view of the values contained in this cache.
-     * The collection maintains the LRU order of the cache.
+     * <p>
+     * The collection is a snapshot with values ordered from most to least
+     * recently used.  Changes to the returned collection or its iterator do not
+     * affect the cache.  Iterator removal only updates the snapshot.
      * This operation requires a full traversal under a lock.
      *
-     * @return a collection view of the values contained in this cache
+     * @return a snapshot collection of the values contained in this cache
      */
     @Override
     public Collection<V> values() {


### PR DESCRIPTION
## Summary
- update `LockingLRUCacheStrategy` javadocs for entrySet, keySet, and values
- note snapshot behavior in `TTLCache.keySet()` and `TTLCache.values()`

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e29e88d14832a95b151a894f4ac02