### PR TITLE
Add test for repeated put with same key

### DIFF
--- a/src/test/java/com/cedarsoftware/util/TTLCacheTest.java
+++ b/src/test/java/com/cedarsoftware/util/TTLCacheTest.java
@@ -344,6 +344,20 @@ public class TTLCacheTest {
     }
 
     @Test
+    void testPutTwiceSameKey() {
+        ttlCache = new TTLCache<>(10000, -1);
+        ttlCache.put(1, "A");
+        ttlCache.put(1, "B");
+
+        assertEquals(1, ttlCache.size());
+        assertEquals("B", ttlCache.get(1));
+
+        TTLCache<Integer, String> expected = new TTLCache<>(10000, -1);
+        expected.put(1, "B");
+        assertEquals(expected.hashCode(), ttlCache.hashCode());
+    }
+
+    @Test
     void testNullValue() {
         ttlCache = new TTLCache<>(10000, 100);
         ttlCache.put(1, null);


### PR DESCRIPTION
## Summary
- add TTLCache test ensuring value replacement doesn't leave extra nodes

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e2be553d0832a8d8cacbede0ee5b5