### PR TITLE
Fix TTLCache.hashCode and add tests

### DIFF
--- a/src/main/java/com/cedarsoftware/util/TTLCache.java
+++ b/src/main/java/com/cedarsoftware/util/TTLCache.java
@@ -538,14 +538,15 @@ public class TTLCache<K, V> implements Map<K, V> {
     public int hashCode() {
         lock.lock();
         try {
-            int hashCode = 1;
-            for (Node<K, V> node = head.next; node != tail; node = node.next) {
-                Object key = node.key;
-                Object value = node.value;
-                hashCode = 31 * hashCode + (key == null ? 0 : key.hashCode());
-                hashCode = 31 * hashCode + (value == null ? 0 : value.hashCode());
+            int hash = 0;
+            for (Map.Entry<K, CacheEntry<K, V>> entry : cacheMap.entrySet()) {
+                K key = entry.getKey();
+                V value = entry.getValue().node.value;
+                int keyHash = (key == null ? 0 : key.hashCode());
+                int valueHash = (value == null ? 0 : value.hashCode());
+                hash += keyHash ^ valueHash;
             }
-            return hashCode;
+            return hash;
         } finally {
             lock.unlock();
         }

--- a/src/test/java/com/cedarsoftware/util/TTLCacheTest.java
+++ b/src/test/java/com/cedarsoftware/util/TTLCacheTest.java
@@ -281,6 +281,24 @@ public class TTLCacheTest {
     }
 
     @Test
+    void testHashCodeConsistencyAfterOperations() {
+        TTLCache<Integer, String> cache = new TTLCache<>(10000, 3);
+        cache.put(1, "A");
+        cache.put(2, "B");
+
+        int initial = cache.hashCode();
+
+        cache.put(3, "C");
+        cache.remove(3);
+        cache.put(2, "B");
+
+        assertEquals(initial, cache.hashCode());
+
+        cache.put(2, "Z");
+        assertNotEquals(initial, cache.hashCode());
+    }
+
+    @Test
     void testToString() {
         ttlCache = new TTLCache<>(10000, -1);
         ttlCache.put(1, "A");


### PR DESCRIPTION
## Summary
- compute TTLCache hash codes using `cacheMap.entrySet()`
- cover key and value hashes to match `equals()` semantics
- add regression tests for `hashCode` stability through cache operations

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e2be66a78832a9fd75555ec9a1093