### PR TITLE
Improve TrackingMap usage tracking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 ### Revision History
+#### 3.3.3 Unreleased
+> * `TrackingMap` - `replaceContents()` replaces the misleading `setWrappedMap()` API. `keysUsed()` now returns an unmodifiable `Set<Object>` and `expungeUnused()` prunes stale keys.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/userguide.md
+++ b/userguide.md
@@ -883,7 +883,7 @@ tracker.expungeUnused();  // Removes entries never accessed
 TrackingMap<String, Config> configMap = new TrackingMap<>(sourceMap);
 
 // After some time...
-Set<String> usedKeys = configMap.keysUsed();
+Set<Object> usedKeys = configMap.keysUsed();
 System.out.println("Accessed configs: " + usedKeys);
 ```
 
@@ -943,7 +943,7 @@ scheduler.scheduleAtFixedRate(() -> {
 ### Available Operations
 ```java
 // Core tracking operations
-Set<K> keysUsed()              // Get accessed keys
+Set<Object> keysUsed()         // Get accessed keys
 void expungeUnused()           // Remove unused entries
 
 // Usage pattern merging
@@ -952,6 +952,7 @@ void informAdditionalUsage(TrackingMap<K,V>) // Merge from another tracker
 
 // Map access
 Map<K,V> getWrappedMap()       // Get underlying map
+void replaceContents(Map<K,V>) // Replace map contents
 ```
 
 ### Thread Safety Notes


### PR DESCRIPTION
## Summary
- track all key accesses without ClassCastException risk
- return immutable set of used keys
- add `replaceContents()` API and deprecate misleading `setWrappedMap`
- prune stale keys in `expungeUnused`
- document the new behavior in the user guide
- update changelog for TrackingMap improvements

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e32840990832a8544c467bd50d17f