### PR TITLE
Fix ConcurrentHashMapNullSafe computeIfAbsent race and docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 >   * EST, MST, HST mapped to fixed offsets (‑05:00, ‑07:00, ‑10:00) when the property sun.timezone.ids.oldmapping=true was set
 >   * The old‑mapping switch was removed, and the short IDs are now links to region IDs: EST → America/Panama, MST → America/Phoenix, HST → Pacific/Honolulu
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
+> * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 #### 3.3.1 New Features and Improvements
 > * `CaseInsensitiveMap/Set` compute hashCodes slightly faster because of update to `StringUtilities.hashCodeIgnoreCase().`  It takes advantage of ASCII for Locale's that use Latin characters.
 > * `CaseInsensitiveString` inside `CaseInsensitiveMap` implements `CharSequence` and can be used outside `CaseInsensitiveMap` as a case-insensitive but case-retentiative String and passed to methods that take `CharSequence.`

--- a/src/main/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMap.java
+++ b/src/main/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMap.java
@@ -210,29 +210,20 @@ public abstract class AbstractConcurrentNullSafeMap<K, V> implements ConcurrentM
 
     @Override
     public V computeIfAbsent(K key, java.util.function.Function<? super K, ? extends V> mappingFunction) {
+        Objects.requireNonNull(mappingFunction);
         Object maskedKey = maskNullKey(key);
-        Object currentValue = internalMap.get(maskNullKey(key));
 
-        if (currentValue != null && currentValue != NullSentinel.NULL_VALUE) {
-            // The key exists with a non-null value, so we don't compute
-            return unmaskNullValue(currentValue);
-        }
+        Object result = internalMap.compute(maskedKey, (k, v) -> {
+            if (v != null && v != NullSentinel.NULL_VALUE) {
+                // Another thread already inserted a value
+                return v;
+            }
 
-        // The key doesn't exist or is mapped to null, so we should compute
-        V newValue = mappingFunction.apply(unmaskNullKey(maskedKey));
-        if (newValue != null) {
-            Object result = internalMap.compute(maskedKey, (k, v) -> {
-                if (v != null && v != NullSentinel.NULL_VALUE) {
-                    return v;  // Another thread set a non-null value, so we keep it
-                }
-                return maskNullValue(newValue);
-            });
-            return unmaskNullValue(result);
-        } else {
-            // If the new computed value is null, ensure no mapping exists
-            internalMap.remove(maskedKey);
-            return null;
-        }
+            V computed = mappingFunction.apply(unmaskNullKey(k));
+            return computed == null ? null : maskNullValue(computed);
+        });
+
+        return unmaskNullValue(result);
     }
 
     @Override

--- a/src/main/java/com/cedarsoftware/util/ConcurrentHashMapNullSafe.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentHashMapNullSafe.java
@@ -18,7 +18,8 @@ import java.util.concurrent.ConcurrentHashMap;
  *   <li>Thread-safe and highly concurrent.</li>
  *   <li>Supports {@code null} keys and {@code null} values through internal sentinel objects.</li>
  *   <li>Adheres to the {@link java.util.Map} and {@link java.util.concurrent.ConcurrentMap} contracts.</li>
- *   <li>Provides multiple constructors to control initial capacity, load factor, and populate from another map.</li>
+ *   <li>Provides constructors to control initial capacity, load factor,
+ *       concurrency level, and to populate from another map.</li>
  * </ul>
  *
  * <h2>Usage Example</h2>
@@ -58,7 +59,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see ConcurrentHashMap
  * @see AbstractConcurrentNullSafeMap
  */
-public class ConcurrentHashMapNullSafe<K, V> extends AbstractConcurrentNullSafeMap<K, V> {
+public final class ConcurrentHashMapNullSafe<K, V> extends AbstractConcurrentNullSafeMap<K, V> {
     /**
      * Constructs a new, empty {@code ConcurrentHashMapNullSafe} with the default initial capacity (16)
      * and load factor (0.75).
@@ -98,6 +99,20 @@ public class ConcurrentHashMapNullSafe<K, V> extends AbstractConcurrentNullSafeM
     }
 
     /**
+     * Constructs a new, empty {@code ConcurrentHashMapNullSafe} with the specified
+     * initial capacity, load factor, and concurrency level.
+     *
+     * @param initialCapacity  the initial capacity of the map
+     * @param loadFactor       the load factor threshold
+     * @param concurrencyLevel the estimated number of concurrently updating threads
+     * @throws IllegalArgumentException if the initial capacity is negative,
+     *                                  or the load factor or concurrency level are nonpositive
+     */
+    public ConcurrentHashMapNullSafe(int initialCapacity, float loadFactor, int concurrencyLevel) {
+        super(new ConcurrentHashMap<>(initialCapacity, loadFactor, concurrencyLevel));
+    }
+
+    /**
      * Constructs a new {@code ConcurrentHashMapNullSafe} with the same mappings as the specified map.
      * <p>
      * This constructor copies all mappings from the given map into the new {@code ConcurrentHashMapNullSafe}.
@@ -108,7 +123,7 @@ public class ConcurrentHashMapNullSafe<K, V> extends AbstractConcurrentNullSafeM
      * @throws NullPointerException if the specified map is {@code null}
      */
     public ConcurrentHashMapNullSafe(Map<? extends K, ? extends V> m) {
-        super(new ConcurrentHashMap<>());
+        super(new ConcurrentHashMap<>(Math.max(16, (int) (m.size() / 0.75f) + 1)));
         putAll(m);
     }
 

--- a/userguide.md
+++ b/userguide.md
@@ -973,7 +973,7 @@ A thread-safe Map implementation that extends ConcurrentHashMap's capabilities b
 - High-performance concurrent operations
 - Full Map and ConcurrentMap interface implementation
 - Maintains ConcurrentHashMap's performance characteristics
-- Configurable initial capacity and load factor
+- Configurable initial capacity, load factor, and concurrency level
 - Atomic operations support
 
 ### Usage Examples
@@ -1000,8 +1000,12 @@ ConcurrentMap<Integer, String> map =
     new ConcurrentHashMapNullSafe<>(1000);
 
 // Create with capacity and load factor
-ConcurrentMap<Integer, String> map = 
+ConcurrentMap<Integer, String> map =
     new ConcurrentHashMapNullSafe<>(1000, 0.75f);
+
+// Create with capacity, load factor, and concurrency level
+ConcurrentMap<Integer, String> tunedMap =
+    new ConcurrentHashMapNullSafe<>(1000, 0.75f, 16);
 ```
 
 **Atomic Operations:**
@@ -1063,6 +1067,9 @@ map.merge("A", 10, Integer::sum);
 - Preserves map contract
 - Consistent serialization behavior
 - Safe iterator implementation
+- `computeIfAbsent` uses a single atomic `compute` call when
+  the mapping function returns `null`, preventing accidental
+  removal of concurrently inserted values
 
 ### Atomic Operation Support
 ```java


### PR DESCRIPTION
## Summary
- prevent concurrent value removal in `computeIfAbsent`
- make `ConcurrentHashMapNullSafe` final
- add constructor accepting concurrency level
- size backing map when copying from another map
- update user guide and changelog

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e32b4c428832ab8f5bd13495f6ccf