### PR TITLE
Improve null-handling and ordering

### DIFF
--- a/userguide.md
+++ b/userguide.md
@@ -1175,8 +1175,8 @@ ConcurrentNavigableMap<String, Integer> tailMap =
 - Hierarchical data management
 
 ### Implementation Notes
-- Based on ConcurrentSkipListMap
-- Null sentinel handling
+- Based on `ConcurrentSkipListMap`
+- Uses a lightweight object sentinel for `null` keys
 - Maintains total ordering
 - Thread-safe navigation
 - Consistent range views


### PR DESCRIPTION
## Summary
- use object sentinel for null keys in `ConcurrentNavigableMapNullSafe`
- improve comparator stability when classes have same name but different loaders
- make `computeIfAbsent` atomic in `AbstractConcurrentNullSafeMap`
- refactor `KeyNavigableSet` to static nested class
- document sentinel change in user guide

## Testing
- `javac @sources.txt -d /tmp/classes`
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e3302e6a0832aa5ba8dc704223aad