### PR TITLE
Improve ConcurrentList thread safety

### DIFF
--- a/src/main/java/com/cedarsoftware/util/ConcurrentList.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentList.java
@@ -1,11 +1,12 @@
 package com.cedarsoftware.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.RandomAccess;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
@@ -86,9 +87,11 @@ import java.util.function.Supplier;
  *         limitations under the License.
  * @see List
  */
-public class ConcurrentList<E> implements List<E> {
+public final class ConcurrentList<E> implements List<E>, RandomAccess, Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final List<E> list;
-    private final transient ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final transient ReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     /**
      * No-arg constructor to create an empty ConcurrentList, wrapping an ArrayList.
@@ -117,48 +120,141 @@ public class ConcurrentList<E> implements List<E> {
     }
 
     // Immutable APIs
-    public boolean equals(Object other) { return readOperation(() -> list.equals(other)); }
-    public int hashCode() { return readOperation(list::hashCode); }
-    public String toString() { return readOperation(list::toString); }
-    public int size() { return readOperation(list::size); }
-    public boolean isEmpty() { return readOperation(list::isEmpty); }
-    public boolean contains(Object o) { return readOperation(() -> list.contains(o)); }
-    public boolean containsAll(Collection<?> c) { return readOperation(() -> new HashSet<>(list).containsAll(c)); }
-    public E get(int index) { return readOperation(() -> list.get(index)); }
-    public int indexOf(Object o) { return readOperation(() -> list.indexOf(o)); }
-    public int lastIndexOf(Object o) { return readOperation(() -> list.lastIndexOf(o)); }
-    public Iterator<E> iterator() { return readOperation(() -> new ArrayList<>(list).iterator()); }
-    public Object[] toArray() { return readOperation(list::toArray); }
-    public <T> T[] toArray(T[] a) { return readOperation(() -> list.toArray(a)); }
+    @Override
+    public boolean equals(Object other) { return withReadLock(() -> list.equals(other)); }
+
+    @Override
+    public int hashCode() { return withReadLock(list::hashCode); }
+
+    @Override
+    public String toString() { return withReadLock(list::toString); }
+
+    @Override
+    public int size() { return withReadLock(list::size); }
+
+    @Override
+    public boolean isEmpty() { return withReadLock(list::isEmpty); }
+
+    @Override
+    public boolean contains(Object o) { return withReadLock(() -> list.contains(o)); }
+
+    @Override
+    public boolean containsAll(Collection<?> c) { return withReadLock(() -> list.containsAll(c)); }
+
+    @Override
+    public E get(int index) { return withReadLock(() -> list.get(index)); }
+
+    @Override
+    public int indexOf(Object o) { return withReadLock(() -> list.indexOf(o)); }
+
+    @Override
+    public int lastIndexOf(Object o) { return withReadLock(() -> list.lastIndexOf(o)); }
+
+    @Override
+    public Iterator<E> iterator() { return new LockedIterator(); }
+
+    @Override
+    public Object[] toArray() { return withReadLock(list::toArray); }
+
+    @Override
+    public <T> T[] toArray(T[] a) { return withReadLock(() -> list.toArray(a)); }
 
     // Mutable APIs
-    public boolean add(E e) { return writeOperation(() -> list.add(e)); }
-    public boolean addAll(Collection<? extends E> c) { return writeOperation(() -> list.addAll(c)); }
-    public boolean addAll(int index, Collection<? extends E> c) { return writeOperation(() -> list.addAll(index, c)); }
+    @Override
+    public boolean add(E e) { return withWriteLock(() -> list.add(e)); }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) { return withWriteLock(() -> list.addAll(c)); }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) { return withWriteLock(() -> list.addAll(index, c)); }
+
+    @Override
     public void add(int index, E element) {
-        writeOperation(() -> {
-            list.add(index, element);
-            return null;
-        });
+        withWriteLockVoid(() -> list.add(index, element));
     }
-    public E set(int index, E element) { return writeOperation(() -> list.set(index, element)); }
-    public E remove(int index) { return writeOperation(() -> list.remove(index)); }
-    public boolean remove(Object o) { return writeOperation(() -> list.remove(o)); }
-    public boolean removeAll(Collection<?> c) { return writeOperation(() -> list.removeAll(c)); }
-    public boolean retainAll(Collection<?> c) { return writeOperation(() -> list.retainAll(c)); }
+
+    @Override
+    public E set(int index, E element) { return withWriteLock(() -> list.set(index, element)); }
+
+    @Override
+    public E remove(int index) { return withWriteLock(() -> list.remove(index)); }
+
+    @Override
+    public boolean remove(Object o) { return withWriteLock(() -> list.remove(o)); }
+
+    @Override
+    public boolean removeAll(Collection<?> c) { return withWriteLock(() -> list.removeAll(c)); }
+
+    @Override
+    public boolean retainAll(Collection<?> c) { return withWriteLock(() -> list.retainAll(c)); }
+
+    @Override
     public void clear() {
-        writeOperation(() -> {
-            list.clear();
-            return null; // To comply with the Supplier<T> return type
-        });
+        withWriteLockVoid(() -> list.clear());
     }
-    public ListIterator<E> listIterator() { return readOperation(() -> new ArrayList<>(list).listIterator()); }
+
+    @Override
+    public ListIterator<E> listIterator() { return new LockedListIterator(0); }
 
     // Unsupported operations
-    public ListIterator<E> listIterator(int index) { throw new UnsupportedOperationException("listIterator(index) not implemented for ConcurrentList"); }
-    public List<E> subList(int fromIndex, int toIndex) { throw new UnsupportedOperationException("subList not implemented for ConcurrentList"); }
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        throw new UnsupportedOperationException("listIterator(index) not implemented for ConcurrentList");
+    }
 
-    private <T> T readOperation(Supplier<T> operation) {
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException("subList not implemented for ConcurrentList");
+    }
+
+    private class LockedIterator implements Iterator<E> {
+        private final LockedListIterator it = new LockedListIterator(0);
+
+        @Override
+        public boolean hasNext() { return it.hasNext(); }
+
+        @Override
+        public E next() { return it.next(); }
+
+        @Override
+        public void remove() { it.remove(); }
+    }
+
+    private class LockedListIterator implements ListIterator<E> {
+        private int cursor;
+
+        LockedListIterator(int index) { this.cursor = index; }
+
+        @Override
+        public boolean hasNext() { return withReadLock(() -> cursor < list.size()); }
+
+        @Override
+        public E next() { return withReadLock(() -> list.get(cursor++)); }
+
+        @Override
+        public boolean hasPrevious() { return withReadLock(() -> cursor > 0); }
+
+        @Override
+        public E previous() { return withReadLock(() -> list.get(--cursor)); }
+
+        @Override
+        public int nextIndex() { return withReadLock(() -> cursor); }
+
+        @Override
+        public int previousIndex() { return withReadLock(() -> cursor - 1); }
+
+        @Override
+        public void remove() { withWriteLock(() -> list.remove(--cursor)); }
+
+        @Override
+        public void set(E e) { withWriteLock(() -> list.set(cursor - 1, e)); }
+
+        @Override
+        public void add(E e) { withWriteLockVoid(() -> list.add(cursor++, e)); }
+    }
+
+    private <T> T withReadLock(Supplier<T> operation) {
         lock.readLock().lock();
         try {
             return operation.get();
@@ -167,10 +263,28 @@ public class ConcurrentList<E> implements List<E> {
         }
     }
 
-    private <T> T writeOperation(Supplier<T> operation) {
+    private void withReadLockVoid(Runnable operation) {
+        lock.readLock().lock();
+        try {
+            operation.run();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    private <T> T withWriteLock(Supplier<T> operation) {
         lock.writeLock().lock();
         try {
             return operation.get();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void withWriteLockVoid(Runnable operation) {
+        lock.writeLock().lock();
+        try {
+            operation.run();
         } finally {
             lock.writeLock().unlock();
         }


### PR DESCRIPTION
## Summary
- mark `ConcurrentList` final and implement `Serializable` and `RandomAccess`
- initialize the internal lock in fair mode
- add missing `@Override` annotations
- avoid temporary `HashSet` in `containsAll`
- add runnable variants of read/write helpers and use them
- introduce locking iterator implementations
- fix ambiguous method overloads with distinct void helper names

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e3a065900832a89e1a073d59a6b3c