### PR TITLE
Improve fractional second parsing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
+> * `DateUtilities` uses `BigDecimal` for fractional second conversion, preventing rounding errors with high precision input
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/DateUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/DateUtilities.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -541,8 +542,16 @@ public final class DateUtilities {
     }
 
     private static long convertFractionToNanos(String fracSec) {
-        double fractionalSecond = Double.parseDouble(fracSec);
-        return (long) (fractionalSecond * 1_000_000_000);
+        if (StringUtilities.isEmpty(fracSec)) {
+            return 0;
+        }
+        BigDecimal fractional = new BigDecimal(fracSec);
+        BigDecimal nanos = fractional.movePointRight(9);
+        if (nanos.compareTo(BigDecimal.ZERO) < 0
+                || nanos.compareTo(BigDecimal.valueOf(1_000_000_000L)) >= 0) {
+            throw new IllegalArgumentException("Invalid fractional second: " + fracSec);
+        }
+        return nanos.longValue();
     }
 
     private static ZoneId getTimeZone(String tz) {


### PR DESCRIPTION
## Summary
- more robust fractional second conversion using BigDecimal
- document change in changelog

## Testing
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e46ccf204832aa9204e6a0607a747