### PR TITLE
Improve ConcurrentList thread safety

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 > * `TrackingMap` - `replaceContents()` replaces the misleading `setWrappedMap()` API. `keysUsed()` now returns an unmodifiable `Set<Object>` and `expungeUnused()` prunes stale keys.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
+> * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
+> * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
+> * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/userguide.md
+++ b/userguide.md
@@ -1306,6 +1306,7 @@ A thread-safe List implementation that provides synchronized access to list oper
 - Exclusive write access
 - Safe collection views
 - Null element support (if backing list allows)
+- Implements `Serializable` and `RandomAccess`
 
 ### Usage Examples
 
@@ -1391,7 +1392,6 @@ while (iterator.hasNext()) {
 - No duplicate creation in wrapper mode
 - Read-only iterator snapshots
 - Unsupported operations:
-    - listIterator(int)
     - subList(int, int)
 
 ### Operation Examples


### PR DESCRIPTION
## Summary
- mark `ConcurrentList` final and implement `Serializable` and `RandomAccess`
- initialize the internal lock in fair mode
- add missing `@Override` annotations
- avoid temporary `HashSet` in `containsAll`
- use snapshot iterators for thread-safe traversal
- add runnable variants of read/write helpers and use them
- add support for `listIterator(int)` via snapshot
- document improvements in changelog and user guide

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e3a065900832a89e1a073d59a6b3c