### PR TITLE
Improve IOUtilities APIs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `Converter` - factory conversions map made immutable and legacy caching code removed
 > * `DateUtilities` uses `BigDecimal` for fractional second conversion, preventing rounding errors with high precision input
+> * `IOUtilities` improved: configurable timeouts, `inputStreamToBytes` throws `IOException` with size limit, offset bug fixed in `uncompressBytes`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/IOUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/IOUtilitiesTest.java
@@ -336,7 +336,7 @@ public class IOUtilitiesTest
     }
 
     @Test
-    public void testInputStreamToBytes()
+    public void testInputStreamToBytes() throws IOException
     {
         ByteArrayInputStream in = new ByteArrayInputStream("This is a test".getBytes());
 

--- a/src/test/java/com/cedarsoftware/util/ReflectionUtilsTest.java
+++ b/src/test/java/com/cedarsoftware/util/ReflectionUtilsTest.java
@@ -1,6 +1,7 @@
 package com.cedarsoftware.util;
 
 import java.io.InputStream;
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -502,7 +503,7 @@ public class ReflectionUtilsTest
     }
 
     @Test
-    public void testGetClassNameFromByteCode()
+    public void testGetClassNameFromByteCode() throws IOException
     {
         Class<?> c = ReflectionUtilsTest.class;
         String className = c.getName();

--- a/userguide.md
+++ b/userguide.md
@@ -2372,15 +2372,16 @@ A comprehensive utility class for I/O operations, providing robust stream handli
 
 ```java
 // Streaming
-public static void transfer(InputStream s, File f, TransferCallback cb) throws Exception
+public static void transfer(InputStream s, File f, TransferCallback cb) throws IOException
 public static void transfer(InputStream in, OutputStream out, TransferCallback cb) throws IOException
 public static void transfer(InputStream in, byte[] bytes) throws IOException
 public static void transfer(InputStream in, OutputStream out) throws IOException
-public static void transfer(File f, URLConnection c, TransferCallback cb) throws Exception
+public static void transfer(File f, URLConnection c, TransferCallback cb) throws IOException
 public static void transfer(File file, OutputStream out) throws IOException
-public static void transfer(URLConnection c, File f, TransferCallback cb) throws Exception
+public static void transfer(URLConnection c, File f, TransferCallback cb) throws IOException
 public static void transfer(URLConnection c, byte[] bytes) throws IOException
-public static byte[] inputStreamToBytes(InputStream in)
+public static byte[] inputStreamToBytes(InputStream in) throws IOException
+public static byte[] inputStreamToBytes(InputStream in, int maxSize) throws IOException
 public static InputStream getInputStream(URLConnection c) throws IOException
     
 // Stream close    
@@ -2479,7 +2480,12 @@ IOUtilities.flush(xmlStreamWriter);
 **Byte Array Operations:**
 ```java
 // Convert InputStream to byte array
-byte[] bytes = IOUtilities.inputStreamToBytes(inputStream);
+byte[] bytes;
+try {
+    bytes = IOUtilities.inputStreamToBytes(inputStream);
+} catch (IOException e) {
+    // handle error
+}
 
 // Transfer exact number of bytes
 byte[] buffer = new byte[1024];


### PR DESCRIPTION
## Summary
- allow configurable timeouts in `IOUtilities`
- add debug logging helpers
- make `inputStreamToBytes` throw `IOException` and support max size
- respect offset in `uncompressBytes`
- flush output streams in `transfer`
- adjust close/flush helpers to log failures
- update docs and tests

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e4751f8d0832ab41a776d3999ad58