### PR TITLE
Improve ReflectionUtils caches

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
+> * `ReflectionUtils` cache size is configurable via the `reflection.utils.cache.size` system property, uses
+  `ConcurrentHashMapNullSafe` for custom caches and generates unique parameter keys using fully qualified names.
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `Converter` - factory conversions map made immutable and legacy caching code removed

--- a/src/main/java/com/cedarsoftware/util/ClassUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ClassUtilities.java
@@ -1511,7 +1511,13 @@ public class ClassUtilities {
     }
 
     static void trySetAccessible(AccessibleObject object) {
-        safelyIgnoreException(() -> object.setAccessible(true));
+        try {
+            object.setAccessible(true);
+        } catch (SecurityException e) {
+            System.err.println("Unable to set accessible: " + object + " - " + e.getMessage());
+        } catch (Throwable t) {
+            safelyIgnoreException(t);
+        }
     }
 
     // Try instantiation via unsafe (if turned on).  It is off by default.  Use

--- a/userguide.md
+++ b/userguide.md
@@ -3276,10 +3276,12 @@ Constructor<?> ctor = ReflectionUtils.getConstructor(
 **Caching Strategy:**
 ```java
 // All operations use internal caching
-private static final int CACHE_SIZE = 1000;
-private static final Map<MethodCacheKey, Method> METHOD_CACHE = 
+// Cache size can be tuned via the 'reflection.utils.cache.size' system property
+private static final int CACHE_SIZE =
+    Integer.getInteger("reflection.utils.cache.size", 1000);
+private static final Map<MethodCacheKey, Method> METHOD_CACHE =
     new LRUCache<>(CACHE_SIZE);
-private static final Map<FieldsCacheKey, Collection<Field>> FIELDS_CACHE = 
+private static final Map<FieldsCacheKey, Collection<Field>> FIELDS_CACHE =
     new LRUCache<>(CACHE_SIZE);
 ```
 


### PR DESCRIPTION
## Summary
- allow ReflectionUtils cache size via system property
- ensure custom caches use ConcurrentHashMapNullSafe
- log failures in ClassUtilities.trySetAccessible
- generate parameter keys using fully qualified names
- document cache size tuning

## Testing
- `mvn -q test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e4790fa68832ab576ed66f6335c72