### PR TITLE
Improve TypeUtilities equality handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
+> * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/TypeUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/TypeUtilities.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Useful APIs for working with Java types, including resolving type variables and generic types.
@@ -41,6 +43,7 @@ public class TypeUtilities {
      *             Must be thread-safe and implement Map interface.
      */
     public static void setTypeResolveCache(Map<Map.Entry<Type, Type>, Type> cache) {
+        Convention.throwIfNull(cache, "cache cannot be null");
         TYPE_RESOLVE_CACHE = cache;
     }
 
@@ -508,6 +511,25 @@ public class TypeUtilities {
             }
             return sb.toString();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ParameterizedType)) {
+                return false;
+            }
+            ParameterizedType that = (ParameterizedType) o;
+            return Objects.equals(raw, that.getRawType()) &&
+                    Objects.equals(owner, that.getOwnerType()) &&
+                    Arrays.equals(args, that.getActualTypeArguments());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(args) ^ Objects.hashCode(raw) ^ Objects.hashCode(owner);
+        }
     }
 
     /**
@@ -528,6 +550,23 @@ public class TypeUtilities {
         @Override
         public String toString() {
             return componentType.getTypeName() + "[]";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GenericArrayType)) {
+                return false;
+            }
+            GenericArrayType that = (GenericArrayType) o;
+            return Objects.equals(componentType, that.getGenericComponentType());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(componentType);
         }
     }
 
@@ -571,6 +610,24 @@ public class TypeUtilities {
                 }
             }
             return sb.toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof WildcardType)) {
+                return false;
+            }
+            WildcardType that = (WildcardType) o;
+            return Arrays.equals(upperBounds, that.getUpperBounds()) &&
+                    Arrays.equals(lowerBounds, that.getLowerBounds());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(upperBounds) ^ Arrays.hashCode(lowerBounds);
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard against null in `setTypeResolveCache`
- implement `equals`/`hashCode` for internal `Type` wrappers
- document new behavior in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e47f004b8832aade77b67ddbc9e84