### PR TITLE
Improve StringUtilities robustness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,9 @@
 > * Documentation for `EncryptionUtilities` updated to list all supported SHA algorithms and note heap buffer usage.
 > * `EncryptionUtilities` now uses AES-GCM with random IV and PBKDF2-derived keys; legacy cipher APIs are deprecated. Added SHA-384 hashing support.
 > * `Executor` now uses `ProcessBuilder` with a 60 second timeout and provides an `ExecutionResult` API
+> * `StringUtilities.decode()` now returns `null` when invalid hexadecimal digits are encountered.
+> * `StringUtilities.getRandomString()` validates parameters and throws descriptive exceptions.
+> * Deprecated `StringUtilities.createUtf8String(byte[])` removed; use `createUTF8String(byte[])` instead.
 > * `IOUtilities` improved: configurable timeouts, `inputStreamToBytes` throws `IOException` with size limit, offset bug fixed in `uncompressBytes`
 > * `MathUtilities` now validates inputs for empty arrays and null lists, fixes documentation, and improves numeric parsing performance
 #### 3.3.2 JDK 24+ Support

--- a/src/test/java/com/cedarsoftware/util/StringUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/StringUtilitiesTest.java
@@ -213,6 +213,7 @@ public class StringUtilitiesTest
         assertArrayEquals(new byte[]{0x1A}, StringUtilities.decode("1A"));
         assertArrayEquals(new byte[]{}, StringUtilities.decode(""));
         assertNull(StringUtilities.decode("1AB"));
+        assertNull(StringUtilities.decode("1Z"));
     }
 
     void testDecodeWithNull()
@@ -469,6 +470,18 @@ public class StringUtilitiesTest
         {
             assertTrue(s.length() >= 3 && s.length() <= 9);
         }
+    }
+
+    @Test
+    void testRandomStringInvalidParams()
+    {
+        Random random = new Random();
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> StringUtilities.getRandomString(null, 1, 2));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> StringUtilities.getRandomString(random, -1, 2));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> StringUtilities.getRandomString(random, 5, 2));
     }
 
     void testGetBytesWithInvalidEncoding() {

--- a/userguide.md
+++ b/userguide.md
@@ -3427,7 +3427,6 @@ public static String getRandomChar(Random random, boolean upper)
 
 // Encoding    
 public static byte[] getBytes(String s, String encoding)
-public static String createUtf8String(byte[] bytes)
 public static byte[] getUTF8Bytes(String s)
 public static String createString(byte[] bytes, String encoding)
 public static String createUTF8String(byte[] bytes)


### PR DESCRIPTION
## Summary
- make constants immutable in `StringUtilities`
- validate hex characters in `decode`
- add argument checks in `getRandomString`
- fix counting algorithm for substrings
- refresh ASCII locale logic when the default locale changes
- make empty result of `commaSeparatedStringToSet` mutable
- remove deprecated `createUtf8String` method
- update documentation and tests

## Testing
- `javac @sources.txt` *(fails: command not found or dependencies missing)*
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e47ad6c3c832a937f19d7afa056e1