### PR TITLE
Improve UniqueIdGenerator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 > * `SystemUtilities` logs shutdown hook failures, handles missing network interfaces and returns immutable address lists
 > * `Traverser` supports lazy field collection, improved null-safe class skipping, and better error logging
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
+> * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.


### PR DESCRIPTION
## Summary
- use java.util.logging for internal logging
- reduce CPU spinning while waiting for next millisecond
- tighten exception handling when resolving server id
- document UniqueIdGenerator changes in changelog

## Testing
- `mvn -q test` *(failed: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e4803d480832a90d30ffe0cef390d