### PR TITLE
Fix lazy field collection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
+> * `Traverser` lazily loads fields when field collection is disabled, fixing missing field data in `NodeVisit`.
 > * `ReflectionUtils` cache size is configurable via the `reflection.utils.cache.size` system property, uses
   `ConcurrentHashMapNullSafe` for custom caches and generates unique parameter keys using fully qualified names.
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`

--- a/src/main/java/com/cedarsoftware/util/Traverser.java
+++ b/src/main/java/com/cedarsoftware/util/Traverser.java
@@ -227,10 +227,11 @@ public class Traverser {
 
             objVisited.add(current);
 
-            java.util.function.Supplier<Map<Field, Object>> supplier = collectFields
-                    ? () -> collectFields(current)
-                    : Collections::emptyMap;
-            nodeVisitor.accept(new NodeVisit(current, supplier));
+            if (collectFields) {
+                nodeVisitor.accept(new NodeVisit(current, collectFields(current)));
+            } else {
+                nodeVisitor.accept(new NodeVisit(current, () -> collectFields(current)));
+            }
 
             if (clazz.isArray()) {
                 processArray(stack, current, classesToSkip);


### PR DESCRIPTION
## Summary
- ensure `Traverser` collects fields lazily when requested
- document the fix in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e62ad0d80832a89cfd1b11ea6ae06