### PR TITLE
Fix failing test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 > * `Traverser` supports lazy field collection, improved null-safe class skipping, and better error logging
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
+> * Fixed `TraverserTest.testLazyFieldCollection` compilation by obtaining the field before the lambda
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/TraverserTest.java
+++ b/src/test/java/com/cedarsoftware/util/TraverserTest.java
@@ -156,10 +156,12 @@ public class TraverserTest
         class Foo { int n = 7; }
         Foo foo = new Foo();
 
+        Field nField = foo.getClass().getDeclaredField("n");
+
         Traverser.traverse(foo, visit -> {
             Map<Field, Object> fields = visit.getFields();
             assertEquals(1, fields.size());
-            assertTrue(fields.containsKey(foo.getClass().getDeclaredField("n")));
+            assertTrue(fields.containsKey(nField));
         }, null, false);
     }
 }


### PR DESCRIPTION
## Summary
- fix testLazyFieldCollection by moving getDeclaredField outside the lambda
- document test fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e63a6a844832ab1871c78cb23382d