### PR TITLE
Ignore synthetic fields in Traverser

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 > * `StringUtilities.getRandomString()` validates parameters and throws descriptive exceptions.
 > * `SystemUtilities` logs shutdown hook failures, handles missing network interfaces and returns immutable address lists
 > * `Traverser` supports lazy field collection, improved null-safe class skipping, and better error logging
+> * `Traverser` now ignores synthetic fields, preventing traversal into outer class references
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Fixed `TraverserTest.testLazyFieldCollection` compilation by obtaining the field before the lambda

--- a/src/main/java/com/cedarsoftware/util/Traverser.java
+++ b/src/main/java/com/cedarsoftware/util/Traverser.java
@@ -247,7 +247,9 @@ public class Traverser {
 
     private Map<Field, Object> collectFields(Object obj) {
         Map<Field, Object> fields = new HashMap<>();
-        Collection<Field> allFields = ReflectionUtils.getAllDeclaredFields(obj.getClass());
+        Collection<Field> allFields = ReflectionUtils.getAllDeclaredFields(
+                obj.getClass(),
+                field -> ReflectionUtils.DEFAULT_FIELD_FILTER.test(field) && !field.isSynthetic());
 
         for (Field field : allFields) {
             try {
@@ -309,7 +311,9 @@ public class Traverser {
     }
 
     private void processFields(Deque<Object> stack, Object object, Set<Class<?>> classesToSkip) {
-        Collection<Field> fields = ReflectionUtils.getAllDeclaredFields(object.getClass());
+        Collection<Field> fields = ReflectionUtils.getAllDeclaredFields(
+                object.getClass(),
+                field -> ReflectionUtils.DEFAULT_FIELD_FILTER.test(field) && !field.isSynthetic());
         for (Field field : fields) {
             if (!field.getType().isPrimitive()) {
                 try {


### PR DESCRIPTION
## Summary
- avoid synthetic fields when visiting objects in `Traverser`
- document change in the changelog

## Testing
- `mvn -q test` *(failed: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e6535d020832aad36c015b4194817