### PR TITLE
Ignore synthetic fields in Traverser

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@
 > * `StringUtilities.getRandomString()` validates parameters and throws descriptive exceptions.
 > * `SystemUtilities` logs shutdown hook failures, handles missing network interfaces and returns immutable address lists
 > * `Traverser` supports lazy field collection, improved null-safe class skipping, and better error logging
+> * `Traverser` now ignores synthetic fields, preventing traversal into outer class references
+> * `Traverser` logs inaccessible fields at `Level.FINEST` instead of printing to STDERR
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Fixed `TraverserTest.testLazyFieldCollection` compilation by obtaining the field before the lambda


### PR DESCRIPTION
## Summary
- avoid synthetic fields when visiting objects in `Traverser`
- document change in the changelog
- log inaccessible fields at `Level.FINEST` instead of printing to stderr

## Testing
- `mvn -q test` *(failed: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684e6535d020832aad36c015b4194817