### PR TITLE
Configure consistent java logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 > * `Executor` now uses `ProcessBuilder` with a 60 second timeout and provides an `ExecutionResult` API
 > * Deprecated `StringUtilities.createUtf8String(byte[])` removed; use `createUTF8String(byte[])` instead.
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
+> * Java logging now uses a Logback-style format for consistency
 > * `IOUtilities` improved: configurable timeouts, `inputStreamToBytes` throws `IOException` with size limit, offset bug fixed in `uncompressBytes`
 > * `MathUtilities` now validates inputs for empty arrays and null lists, fixes documentation, and improves numeric parsing performance
 > * `StringUtilities.decode()` now returns `null` when invalid hexadecimal digits are encountered.

--- a/src/main/java/com/cedarsoftware/util/ClassUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ClassUtilities.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
@@ -192,6 +193,7 @@ import static com.cedarsoftware.util.ExceptionUtilities.safelyIgnoreException;
 public class ClassUtilities {
 
     private static final Logger LOG = Logger.getLogger(ClassUtilities.class.getName());
+    static { LoggingConfig.init(); }
 
     private ClassUtilities() {
     }

--- a/src/main/java/com/cedarsoftware/util/Executor.java
+++ b/src/main/java/com/cedarsoftware/util/Executor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 
 /**
  * A utility class for executing system commands and capturing their output.
@@ -56,6 +57,7 @@ public class Executor {
     private String _out;
     private static final long DEFAULT_TIMEOUT_SECONDS = 60L;
     private static final Logger LOG = Logger.getLogger(Executor.class.getName());
+    static { LoggingConfig.init(); }
 
     public ExecutionResult execute(String command) {
         return execute(command, null, null);

--- a/src/main/java/com/cedarsoftware/util/IOUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/IOUtilities.java
@@ -26,6 +26,7 @@ import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 
 /**
  * Utility class providing robust I/O operations with built-in error handling and resource management.
@@ -91,6 +92,7 @@ public final class IOUtilities {
     private static final int DEFAULT_READ_TIMEOUT = 30000;
     private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("io.debug", "false"));
     private static final Logger LOG = Logger.getLogger(IOUtilities.class.getName());
+    static { LoggingConfig.init(); }
 
     private static void debug(String msg, Exception e) {
         if (DEBUG) {

--- a/src/main/java/com/cedarsoftware/util/InetAddressUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/InetAddressUtilities.java
@@ -4,6 +4,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 
 /**
  * Useful InetAddress Utilities
@@ -27,6 +28,7 @@ import java.util.logging.Logger;
 public class InetAddressUtilities
 {
     private static final Logger LOG = Logger.getLogger(InetAddressUtilities.class.getName());
+    static { LoggingConfig.init(); }
     private InetAddressUtilities() {
         super();
     }

--- a/src/main/java/com/cedarsoftware/util/LoggingConfig.java
+++ b/src/main/java/com/cedarsoftware/util/LoggingConfig.java
@@ -1,0 +1,70 @@
+package com.cedarsoftware.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Configures java.util.logging to use a uniform log format similar to
+ * popular frameworks like SLF4J/Logback.
+ */
+public final class LoggingConfig {
+    private static volatile boolean initialized = false;
+
+    private LoggingConfig() {
+    }
+
+    /**
+     * Initialize logging if not already configured.
+     */
+    public static synchronized void init() {
+        if (initialized) {
+            return;
+        }
+        Logger root = LogManager.getLogManager().getLogger("");
+        for (Handler h : root.getHandlers()) {
+            if (h instanceof ConsoleHandler) {
+                h.setFormatter(new UniformFormatter());
+            }
+        }
+        initialized = true;
+    }
+
+    private static class UniformFormatter extends Formatter {
+        private final DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+        @Override
+        public synchronized String format(LogRecord r) {
+            String ts = df.format(new Date(r.getMillis()));
+            String level = r.getLevel().getName();
+            String logger = r.getLoggerName();
+            String msg = formatMessage(r);
+            String thread = Thread.currentThread().getName();
+            StringBuilder sb = new StringBuilder();
+            sb.append(ts)
+              .append(' ')
+              .append('[').append(thread).append(']')
+              .append(' ')
+              .append(String.format("%-5s", level))
+              .append(' ')
+              .append(logger)
+              .append(" - ")
+              .append(msg);
+            if (r.getThrown() != null) {
+                StringWriter sw = new StringWriter();
+                r.getThrown().printStackTrace(new PrintWriter(sw));
+                sb.append(System.lineSeparator()).append(sw);
+            }
+            sb.append(System.lineSeparator());
+            return sb.toString();
+        }
+    }
+}

--- a/src/main/java/com/cedarsoftware/util/SystemUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/SystemUtilities.java
@@ -17,6 +17,7 @@ import java.util.TimeZone;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 import java.util.stream.Collectors;
 
 /**
@@ -77,6 +78,7 @@ public final class SystemUtilities
     public static final String USER_HOME = System.getProperty("user.home");
     public static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
     private static final Logger LOG = Logger.getLogger(SystemUtilities.class.getName());
+    static { LoggingConfig.init(); }
 
     private SystemUtilities() {
     }

--- a/src/main/java/com/cedarsoftware/util/Traverser.java
+++ b/src/main/java/com/cedarsoftware/util/Traverser.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 
 /**
  * A Java Object Graph traverser that visits all object reference fields and invokes a
@@ -87,6 +88,7 @@ import java.util.logging.Logger;
 public class Traverser {
 
     private static final Logger LOG = Logger.getLogger(Traverser.class.getName());
+    static { LoggingConfig.init(); }
 
     /**
      * Represents a node visit during traversal, containing the node and its field information.

--- a/src/main/java/com/cedarsoftware/util/UniqueIdGenerator.java
+++ b/src/main/java/com/cedarsoftware/util/UniqueIdGenerator.java
@@ -8,6 +8,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 
 import static java.lang.Integer.parseInt;
 import static java.lang.Math.abs;
@@ -88,6 +89,7 @@ public final class UniqueIdGenerator {
     private static final Lock lock = new ReentrantLock();
     private static final Lock lock19 = new ReentrantLock();
     private static final Logger LOG = Logger.getLogger(UniqueIdGenerator.class.getName());
+    static { LoggingConfig.init(); }
     private static int count = 0;
     private static int count2 = 0;
     private static long lastTimeMillis = 0;

--- a/src/main/java/com/cedarsoftware/util/UrlUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/UrlUtilities.java
@@ -10,6 +10,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.cedarsoftware.util.LoggingConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,6 +108,7 @@ public final class UrlUtilities
 
     protected static SSLSocketFactory naiveSSLSocketFactory;
     private static final Logger LOG = Logger.getLogger(UrlUtilities.class.getName());
+    static { LoggingConfig.init(); }
 
     static
     {

--- a/userguide.md
+++ b/userguide.md
@@ -4225,3 +4225,9 @@ for (int i = 0; i < batchSize; i++) {
 
 ### Support
 For additional support or to report issues, please refer to the project's GitHub repository or documentation.
+
+## LoggingConfig
+[Source](/src/main/java/com/cedarsoftware/util/LoggingConfig.java)
+
+`LoggingConfig` sets up a consistent console format for `java.util.logging`. Call `LoggingConfig.init()` once during application startup to configure the root logger with a Logback-style pattern.
+


### PR DESCRIPTION
## Summary
- add `LoggingConfig` for unified log formatting
- use `LoggingConfig.init()` in classes that log
- document logging config
- note change in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e6b3819d8832ab98a55d553d11dc3