### PR TITLE
Improve logging doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ implementation 'com.cedarsoftware:java-util:3.3.2'
 
 ### Redirecting java.util.logging
 
-This library uses `java.util.logging.Logger` for all diagnostics. To integrate these
-messages with frameworks like SLF4J or Logback, include the `jul-to-slf4j`
-bridge and install the handler at application startup:
+This library relies solely on `java.util.logging.Logger` so that no additional
+logging dependencies are pulled in. Small libraries often take this approach to
+remain lightweight. Applications that prefer a different logging framework can
+redirect these messages using one of the adapters below, ordered roughly by
+their usage across Maven Central.
+
+#### 1. SLF4J
+
+Add the `jul-to-slf4j` bridge and install it during startup:
 
 ```java
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -108,8 +114,26 @@ SLF4JBridgeHandler.removeHandlersForRootLogger();
 SLF4JBridgeHandler.install();
 ```
 
-For Log4j&nbsp;2, use the `log4j-jul` adapter and launch the JVM with
-`-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager`.
+SLF4J is the most common façade; it works with Logback, Log4j&nbsp;2 and many
+other implementations.
+
+#### 2. Logback
+
+Logback uses SLF4J natively, so the configuration is the same as above. Include
+`jul-to-slf4j` on the classpath and install the `SLF4JBridgeHandler`.
+
+#### 3. Log4j&nbsp;2
+
+Use the `log4j-jul` adapter and start the JVM with:
+
+```bash
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+```
+
+This routes all `java.util.logging` output to Log4j&nbsp;2.
+
+Most consumers are comfortable bridging JUL output when needed, so relying on
+`java.util.logging` by default generally is not considered burdensome.
 
 [View detailed documentation](userguide.md)
 

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)
+> * README clarifies the configuration for each logger and notes that small libraries often rely on `java.util.logging`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.


### PR DESCRIPTION
## Summary
- clarify how to route `java.util.logging` to popular frameworks
- note typical usage of JUL in small libs

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e6da437dc832ab24c466c93de9ce0