### PR TITLE
Improve logging flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ remain lightweight. Applications that prefer a different logging framework can
 redirect these messages using one of the adapters below, ordered roughly by
 their usage across Maven Central.
 
+`java-util` provides `LoggingConfig` to apply a consistent console
+format. Call `LoggingConfig.init()` to use the default pattern or pass a
+custom pattern via `LoggingConfig.init("yyyy/MM/dd HH:mm:ss")`. The pattern
+can also be supplied with the system property `ju.log.dateFormat`.
+
 #### 1. SLF4J
 
 Add the `jul-to-slf4j` bridge and install it during startup:

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 > * `TrackingMap` - `replaceContents()` replaces the misleading `setWrappedMap()` API. `keysUsed()` now returns an unmodifiable `Set<Object>` and `expungeUnused()` prunes stale keys.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
+> * `LoggingConfig` can now accept a custom timestamp pattern via `LoggingConfig.init(String)` or
+  the `ju.log.dateFormat` system property. Uses thread-safe `SafeSimpleDateFormat`.
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.

--- a/src/main/java/com/cedarsoftware/util/LoggingConfig.java
+++ b/src/main/java/com/cedarsoftware/util/LoggingConfig.java
@@ -3,7 +3,7 @@ package com.cedarsoftware.util;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.util.Objects;
 import java.util.Date;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Formatter;
@@ -12,11 +12,15 @@ import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import com.cedarsoftware.util.SafeSimpleDateFormat;
+
 /**
  * Configures java.util.logging to use a uniform log format similar to
  * popular frameworks like SLF4J/Logback.
  */
 public final class LoggingConfig {
+    private static final String DATE_FORMAT_PROP = "ju.log.dateFormat";
+    private static final String DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";
     private static volatile boolean initialized = false;
 
     private LoggingConfig() {
@@ -24,25 +28,60 @@ public final class LoggingConfig {
 
     /**
      * Initialize logging if not already configured.
+     * The formatter pattern can be set via system property {@value #DATE_FORMAT_PROP}
+     * or by calling {@link #init(String)}.
      */
     public static synchronized void init() {
+        init(System.getProperty(DATE_FORMAT_PROP, DEFAULT_PATTERN));
+    }
+
+    /**
+     * Initialize logging with the supplied date pattern if not already configured.
+     *
+     * @param datePattern pattern passed to {@link SafeSimpleDateFormat}
+     */
+    public static synchronized void init(String datePattern) {
         if (initialized) {
             return;
         }
         Logger root = LogManager.getLogManager().getLogger("");
         for (Handler h : root.getHandlers()) {
             if (h instanceof ConsoleHandler) {
-                h.setFormatter(new UniformFormatter());
+                h.setFormatter(new UniformFormatter(datePattern));
             }
         }
         initialized = true;
     }
 
-    private static class UniformFormatter extends Formatter {
-        private final DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    /**
+     * Set the {@link UniformFormatter} on the supplied handler.
+     *
+     * @param handler the handler to configure
+     */
+    public static void useUniformFormatter(Handler handler) {
+        if (handler != null) {
+            handler.setFormatter(new UniformFormatter(System.getProperty(DATE_FORMAT_PROP, DEFAULT_PATTERN)));
+        }
+    }
+
+    /**
+     * Formatter producing logs in the pattern:
+     * {@code yyyy-MM-dd HH:mm:ss.SSS [thread] LEVEL logger - message}
+     */
+    public static class UniformFormatter extends Formatter {
+        private final DateFormat df;
+
+        public UniformFormatter() {
+            this(DEFAULT_PATTERN);
+        }
+
+        public UniformFormatter(String pattern) {
+            Objects.requireNonNull(pattern, "pattern");
+            this.df = new SafeSimpleDateFormat(pattern);
+        }
 
         @Override
-        public synchronized String format(LogRecord r) {
+        public String format(LogRecord r) {
             String ts = df.format(new Date(r.getMillis()));
             String level = r.getLevel().getName();
             String logger = r.getLoggerName();

--- a/userguide.md
+++ b/userguide.md
@@ -4241,5 +4241,8 @@ For additional support or to report issues, please refer to the project's GitHub
 ## LoggingConfig
 [Source](/src/main/java/com/cedarsoftware/util/LoggingConfig.java)
 
-`LoggingConfig` sets up a consistent console format for `java.util.logging`. Call `LoggingConfig.init()` once during application startup to configure the root logger with a Logback-style pattern.
+`LoggingConfig` applies a consistent console format for `java.util.logging`.
+Call `LoggingConfig.init()` once during application startup. You may supply a
+custom timestamp pattern via `LoggingConfig.init("yyyy/MM/dd HH:mm:ss")` or the
+system property `ju.log.dateFormat`.
 


### PR DESCRIPTION
## Summary
- allow custom date pattern in `LoggingConfig`
- expose `LoggingConfig.UniformFormatter` and utility to set handler format
- document new logging options

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e70c36f78832a87d1ecf208334797