### PR TITLE
Add tests for case-insensitive utilities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
+> * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/CaseInsensitiveMapTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -2626,6 +2627,29 @@ void testComputeIfAbsent() {
     @Test
     public void testInvalidMaxLength() {
         assertThrows(IllegalArgumentException.class, () -> CaseInsensitiveMap.setMaxCacheLengthString(9));
+    }
+
+    @Test
+    public void testCaseInsensitiveStringSubSequence() {
+        CaseInsensitiveMap.CaseInsensitiveString cis = new CaseInsensitiveMap.CaseInsensitiveString("Hello");
+        CharSequence seq = cis.subSequence(1, 4);
+        assertEquals("ell", seq.toString());
+    }
+
+    @Test
+    public void testCaseInsensitiveStringChars() {
+        String str = "a\uD83D\uDE00b";
+        CaseInsensitiveMap.CaseInsensitiveString cis = new CaseInsensitiveMap.CaseInsensitiveString(str);
+        int[] expected = str.chars().toArray();
+        assertArrayEquals(expected, cis.chars().toArray());
+    }
+
+    @Test
+    public void testCaseInsensitiveStringCodePoints() {
+        String str = "a\uD83D\uDE00b";
+        CaseInsensitiveMap.CaseInsensitiveString cis = new CaseInsensitiveMap.CaseInsensitiveString(str);
+        int[] expected = str.codePoints().toArray();
+        assertArrayEquals(expected, cis.codePoints().toArray());
     }
 
     // ---------------------------------------------------

--- a/src/test/java/com/cedarsoftware/util/CaseInsensitiveSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/CaseInsensitiveSetTest.java
@@ -537,6 +537,36 @@ public class CaseInsensitiveSetTest
         assert !set.equals(other);
     }
 
+    /**
+     * Verifies the deprecated {@code plus(Object)} and {@code minus(E)} methods.
+     * This test should be removed when these methods are deleted.
+     */
+    @Test
+    public void testDeprecatedPlusMinusSingle()
+    {
+        CaseInsensitiveSet<String> set = new CaseInsensitiveSet<>();
+        set.add("alpha");
+        set.plus("beta");
+        assertTrue(set.contains("BETA"));
+        set.minus("alpha");
+        assertFalse(set.contains("ALPHA"));
+    }
+
+    /**
+     * Verifies the deprecated {@code plus(Iterable)} and {@code minus(Iterable)} methods.
+     * This test should be removed when the deprecated APIs are removed.
+     */
+    @Test
+    public void testDeprecatedPlusMinusIterable()
+    {
+        CaseInsensitiveSet<String> set = new CaseInsensitiveSet<>();
+        set.add("foo");
+        set.plus(Arrays.asList("bar", "baz"));
+        assertTrue(set.contains("BAR") && set.contains("BAZ"));
+        set.minus(Collections.singletonList("foo"));
+        assertFalse(set.contains("FOO"));
+    }
+
     private static Set<Object> get123()
     {
         Set<Object> set = new CaseInsensitiveSet<>();


### PR DESCRIPTION
## Summary
- add JUnit tests for CaseInsensitiveMap.CaseInsensitiveString subSequence, chars and codePoints
- test deprecated CaseInsensitiveSet plus/minus methods
- note new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e7e729640832aa5a3ded20892b22f