### PR TITLE
Add CollectionsWrappers tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
 > * `TypeUtilities.setTypeResolveCache()` validates that the supplied cache is not null and inner `Type` implementations now implement `equals` and `hashCode`
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
+> * Added tests for cached wrapper classes returned by `CollectionsWrappers`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/CollectionsWrappersTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/CollectionsWrappersTest.java
@@ -1,0 +1,88 @@
+package com.cedarsoftware.util.convert;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CollectionsWrappersTest {
+
+    @Test
+    void testGetCheckedListClass() {
+        List<String> checked = Collections.checkedList(new ArrayList<>(), String.class);
+        assertSame(checked.getClass(), CollectionsWrappers.getCheckedListClass());
+        checked.add("a");
+        assertThrows(ClassCastException.class, () -> ((List) checked).add(1));
+    }
+
+    @Test
+    void testGetCheckedSortedSetClass() {
+        SortedSet<String> checked = Collections.checkedSortedSet(new TreeSet<>(), String.class);
+        assertSame(checked.getClass(), CollectionsWrappers.getCheckedSortedSetClass());
+        checked.add("a");
+        assertThrows(ClassCastException.class, () -> ((SortedSet) checked).add(1));
+    }
+
+    @Test
+    void testGetCheckedNavigableSetClass() {
+        NavigableSet<String> checked = Collections.checkedNavigableSet(new TreeSet<>(), String.class);
+        assertSame(checked.getClass(), CollectionsWrappers.getCheckedNavigableSetClass());
+        checked.add("a");
+        assertThrows(ClassCastException.class, () -> ((NavigableSet) checked).add(1));
+    }
+
+    @Test
+    void testGetEmptySetClass() {
+        Set<Object> empty = Collections.emptySet();
+        assertSame(empty.getClass(), CollectionsWrappers.getEmptySetClass());
+        assertTrue(empty.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> empty.add("x"));
+    }
+
+    @Test
+    void testGetEmptySortedSetClass() {
+        SortedSet<Object> empty = Collections.emptySortedSet();
+        assertSame(empty.getClass(), CollectionsWrappers.getEmptySortedSetClass());
+        assertTrue(empty.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> empty.add("x"));
+    }
+
+    @Test
+    void testGetEmptyNavigableSetClass() {
+        NavigableSet<Object> empty = Collections.emptyNavigableSet();
+        assertSame(empty.getClass(), CollectionsWrappers.getEmptyNavigableSetClass());
+        assertTrue(empty.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> empty.add("x"));
+    }
+
+    @Test
+    void testGetSynchronizedListClass() {
+        List<String> syncList = Collections.synchronizedList(new ArrayList<>());
+        assertSame(syncList.getClass(), CollectionsWrappers.getSynchronizedListClass());
+        synchronized (syncList) {
+            syncList.add("a");
+        }
+        assertTrue(syncList.contains("a"));
+    }
+
+    @Test
+    void testGetSynchronizedSortedSetClass() {
+        SortedSet<String> syncSet = Collections.synchronizedSortedSet(new TreeSet<>());
+        assertSame(syncSet.getClass(), CollectionsWrappers.getSynchronizedSortedSetClass());
+        synchronized (syncSet) {
+            syncSet.add("a");
+        }
+        assertTrue(syncSet.contains("a"));
+    }
+
+    @Test
+    void testGetSynchronizedNavigableSetClass() {
+        NavigableSet<String> syncNav = Collections.synchronizedNavigableSet(new TreeSet<>());
+        assertSame(syncNav.getClass(), CollectionsWrappers.getSynchronizedNavigableSetClass());
+        synchronized (syncNav) {
+            syncNav.add("a");
+        }
+        assertTrue(syncNav.contains("a"));
+    }
+}


### PR DESCRIPTION
## Summary
- add new JUnit 5 tests covering CollectionsWrappers getters
- document test addition in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e80a9a840832aaa79e32b14499f76