### PR TITLE
Fix unmodifiable collection test generics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
+> * Tests use `CollectionsWrappers` to obtain wrapper classes, fixing generics warnings in `CollectionConversionsDirectTest`.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.

--- a/src/test/java/com/cedarsoftware/util/convert/CollectionConversionsDirectTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/CollectionConversionsDirectTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.cedarsoftware.util.CollectionUtilities;
+import com.cedarsoftware.util.convert.CollectionsWrappers;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,7 +30,7 @@ class CollectionConversionsDirectTest {
 
     @Test
     void arrayToCollectionCreatesUnmodifiable() {
-        Class<? extends Collection<?>> type = Collections.unmodifiableCollection(new ArrayList<>()).getClass();
+        Class<? extends Collection<?>> type = CollectionsWrappers.getUnmodifiableCollectionClass();
         Collection<?> result = CollectionConversions.arrayToCollection(new Integer[]{1, 2}, type);
         assertTrue(CollectionUtilities.isUnmodifiable(result.getClass()));
         assertThrows(UnsupportedOperationException.class, () -> result.add(3));
@@ -37,7 +38,7 @@ class CollectionConversionsDirectTest {
 
     @Test
     void arrayToCollectionCreatesSynchronized() {
-        Class<? extends Collection<?>> type = Collections.synchronizedCollection(new ArrayList<>()).getClass();
+        Class<? extends Collection<?>> type = CollectionsWrappers.getSynchronizedCollectionClass();
         Collection<?> result = CollectionConversions.arrayToCollection(new String[]{"x"}, type);
         assertTrue(CollectionUtilities.isSynchronized(result.getClass()));
         assertDoesNotThrow(() -> result.add("y"));


### PR DESCRIPTION
## Summary
- use CollectionsWrappers helpers in CollectionConversionsDirectTest
- note generic fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e8abbd120832ab13d508fa4bb8e06