### PR TITLE
Add tests for isDefaultCompactSet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `CompactSet.isDefaultCompactSet`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/CompactSetIsDefaultTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactSetIsDefaultTest.java
@@ -1,0 +1,25 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompactSetIsDefaultTest {
+
+    @Test
+    void defaultSetIsRecognized() {
+        CompactSet<String> set = new CompactSet<>();
+        assertTrue(set.isDefaultCompactSet());
+    }
+
+    @Test
+    void customSetIsNotRecognized() {
+        CompactSet<String> set = CompactSet.<String>builder()
+                .caseSensitive(false)
+                .compactSize(10)
+                .sortedOrder()
+                .build();
+        assertFalse(set.isDefaultCompactSet());
+    }
+}


### PR DESCRIPTION
## Summary
- cover `CompactSet.isDefaultCompactSet` behavior
- document new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e82182450832aafab7d6385d2ec45