### PR TITLE
Fix compile error in collection tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * Tests use `CollectionsWrappers` to obtain wrapper classes, fixing generics warnings in `CollectionConversionsDirectTest`.
+> * Fixed compile error in `CollectionConversionsDirectTest` when adding to wildcard collections.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.

--- a/src/test/java/com/cedarsoftware/util/convert/CollectionConversionsDirectTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/CollectionConversionsDirectTest.java
@@ -33,7 +33,8 @@ class CollectionConversionsDirectTest {
         Class<? extends Collection<?>> type = CollectionsWrappers.getUnmodifiableCollectionClass();
         Collection<?> result = CollectionConversions.arrayToCollection(new Integer[]{1, 2}, type);
         assertTrue(CollectionUtilities.isUnmodifiable(result.getClass()));
-        assertThrows(UnsupportedOperationException.class, () -> result.add(3));
+        assertThrows(UnsupportedOperationException.class,
+                () -> ((Collection<Object>) result).add(3));
     }
 
     @Test
@@ -41,7 +42,7 @@ class CollectionConversionsDirectTest {
         Class<? extends Collection<?>> type = CollectionsWrappers.getSynchronizedCollectionClass();
         Collection<?> result = CollectionConversions.arrayToCollection(new String[]{"x"}, type);
         assertTrue(CollectionUtilities.isSynchronized(result.getClass()));
-        assertDoesNotThrow(() -> result.add("y"));
+        assertDoesNotThrow(() -> ((Collection<Object>) result).add("y"));
     }
 
     @Test
@@ -61,7 +62,8 @@ class CollectionConversionsDirectTest {
         Class<?> type = Collections.unmodifiableCollection(new ArrayList<>()).getClass();
         Collection<?> result = (Collection<?>) CollectionConversions.collectionToCollection(List.of(1, 2), type);
         assertTrue(CollectionUtilities.isUnmodifiable(result.getClass()));
-        assertThrows(UnsupportedOperationException.class, () -> result.add(3));
+        assertThrows(UnsupportedOperationException.class,
+                () -> ((Collection<Object>) result).add(3));
     }
 
     @Test
@@ -69,7 +71,7 @@ class CollectionConversionsDirectTest {
         Class<?> type = Collections.synchronizedCollection(new ArrayList<>()).getClass();
         Collection<?> result = (Collection<?>) CollectionConversions.collectionToCollection(List.of("a"), type);
         assertTrue(CollectionUtilities.isSynchronized(result.getClass()));
-        assertDoesNotThrow(() -> result.add("b"));
+        assertDoesNotThrow(() -> ((Collection<Object>) result).add("b"));
     }
 }
 


### PR DESCRIPTION
## Summary
- cast wildcard collections to add elements in tests
- note compile fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e8c90a804832a9b5ddbacf074410e