### PR TITLE
Add descending iterator tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,8 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `ConcurrentNavigableMapNullSafe.descendingIterator` and
+>   `ConcurrentNavigableSetNullSafe.descendingIterator`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeTest.java
@@ -399,6 +399,34 @@ class ConcurrentNavigableMapNullSafeTest {
 
 
     @Test
+    void testKeySetDescendingIterator() {
+        map.put("apple", 1);
+        map.put("banana", 2);
+        map.put("cherry", 3);
+        map.put(null, 0);
+
+        Iterator<String> it = map.keySet().descendingIterator();
+
+        assertEquals(null, it.next());
+        it.remove();
+        assertFalse(map.containsKey(null));
+
+        assertEquals("cherry", it.next());
+        it.remove();
+        assertFalse(map.containsKey("cherry"));
+
+        assertEquals("banana", it.next());
+        it.remove();
+        assertFalse(map.containsKey("banana"));
+
+        assertEquals("apple", it.next());
+        it.remove();
+        assertFalse(it.hasNext());
+        assertTrue(map.isEmpty());
+    }
+
+
+    @Test
     void testSubMap() {
         map.put("apple", 1);
         map.put("banana", 2);

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
@@ -232,6 +232,34 @@ class ConcurrentNavigableSetNullSafeTest {
     }
 
     @Test
+    void testDescendingIterator() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add(null);
+
+        Iterator<String> it = set.descendingIterator();
+
+        assertEquals(null, it.next());
+        it.remove();
+        assertFalse(set.contains(null));
+
+        assertEquals("cherry", it.next());
+        it.remove();
+        assertFalse(set.contains("cherry"));
+
+        assertEquals("banana", it.next());
+        it.remove();
+        assertFalse(set.contains("banana"));
+
+        assertEquals("apple", it.next());
+        it.remove();
+        assertFalse(it.hasNext());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
     void testSubSet() {
         NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
         set.add("apple");


### PR DESCRIPTION
## Summary
- add coverage for descendingIterator in ConcurrentNavigableMapNullSafe
- add coverage for descendingIterator in ConcurrentNavigableSetNullSafe
- document test addition in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e82293a68832a96841a27b7c4a1d2