### PR TITLE
Adjust atomic assertions in tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Tests updated to assert values within `AtomicBoolean`, `AtomicInteger`, and `AtomicLong` wrappers.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConverterLegacyApiTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConverterLegacyApiTest.java
@@ -54,7 +54,16 @@ class ConverterLegacyApiTest {
     @ParameterizedTest
     @MethodSource("convert2GoodData")
     void convert2_goodData(ConversionFunction func, Object input, Object expected) {
-        assertThat(func.apply(input)).isEqualTo(expected);
+        Object result = func.apply(input);
+        if (expected instanceof AtomicBoolean) {
+            assertThat(((AtomicBoolean) result).get()).isEqualTo(((AtomicBoolean) expected).get());
+        } else if (expected instanceof AtomicInteger) {
+            assertThat(((AtomicInteger) result).get()).isEqualTo(((AtomicInteger) expected).get());
+        } else if (expected instanceof AtomicLong) {
+            assertThat(((AtomicLong) result).get()).isEqualTo(((AtomicLong) expected).get());
+        } else {
+            assertThat(result).isEqualTo(expected);
+        }
     }
 
     private static Stream<Arguments> convert2NullData() {
@@ -79,7 +88,16 @@ class ConverterLegacyApiTest {
     @ParameterizedTest
     @MethodSource("convert2NullData")
     void convert2_nullReturnsDefault(ConversionFunction func, Object expected) {
-        assertThat(func.apply(null)).isEqualTo(expected);
+        Object result = func.apply(null);
+        if (expected instanceof AtomicBoolean) {
+            assertThat(((AtomicBoolean) result).get()).isEqualTo(((AtomicBoolean) expected).get());
+        } else if (expected instanceof AtomicInteger) {
+            assertThat(((AtomicInteger) result).get()).isEqualTo(((AtomicInteger) expected).get());
+        } else if (expected instanceof AtomicLong) {
+            assertThat(((AtomicLong) result).get()).isEqualTo(((AtomicLong) expected).get());
+        } else {
+            assertThat(result).isEqualTo(expected);
+        }
     }
 
     private static Stream<Arguments> convert2BadData() {
@@ -143,7 +161,13 @@ class ConverterLegacyApiTest {
     @MethodSource("convertToGoodData")
     void convertTo_goodData(ConversionFunction func, Object input, Object expected) {
         Object result = func.apply(input);
-        if (result instanceof Calendar) {
+        if (expected instanceof AtomicBoolean) {
+            assertThat(((AtomicBoolean) result).get()).isEqualTo(((AtomicBoolean) expected).get());
+        } else if (expected instanceof AtomicInteger) {
+            assertThat(((AtomicInteger) result).get()).isEqualTo(((AtomicInteger) expected).get());
+        } else if (expected instanceof AtomicLong) {
+            assertThat(((AtomicLong) result).get()).isEqualTo(((AtomicLong) expected).get());
+        } else if (result instanceof Calendar) {
             assertThat(((Calendar) result).getTime()).isEqualTo(((Calendar) expected).getTime());
         } else {
             assertThat(result).isEqualTo(expected);


### PR DESCRIPTION
## Summary
- refine tests to compare atomic values via `.get()`
- update changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e9169d7a0832aba3f445d07a62715