### PR TITLE
Add LoggingConfig tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### Revision History
 #### 3.3.3 Unreleased
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
+> * Added JUnit tests for `LoggingConfig.init` and `useUniformFormatter`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
 > * Java logging now uses a Logback-style format for consistency
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)

--- a/src/test/java/com/cedarsoftware/util/LoggingConfigTest.java
+++ b/src/test/java/com/cedarsoftware/util/LoggingConfigTest.java
@@ -1,0 +1,68 @@
+package com.cedarsoftware.util;
+
+import java.lang.reflect.Field;
+import java.text.DateFormat;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.logging.Formatter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LoggingConfigTest {
+
+    private static String getPattern(Formatter formatter) throws Exception {
+        assertTrue(formatter instanceof LoggingConfig.UniformFormatter);
+        Field dfField = LoggingConfig.UniformFormatter.class.getDeclaredField("df");
+        dfField.setAccessible(true);
+        DateFormat df = (DateFormat) dfField.get(formatter);
+        return df.toString();
+    }
+
+    @Test
+    public void testUseUniformFormatter() throws Exception {
+        ConsoleHandler handler = new ConsoleHandler();
+        System.setProperty("ju.log.dateFormat", "MM/dd");
+        try {
+            LoggingConfig.useUniformFormatter(handler);
+            assertTrue(handler.getFormatter() instanceof LoggingConfig.UniformFormatter);
+            assertEquals("MM/dd", getPattern(handler.getFormatter()));
+            LoggingConfig.useUniformFormatter(null);  // should not throw
+        } finally {
+            System.clearProperty("ju.log.dateFormat");
+        }
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        Logger root = LogManager.getLogManager().getLogger("");
+        Handler[] original = root.getHandlers();
+        for (Handler h : original) {
+            root.removeHandler(h);
+        }
+        ConsoleHandler testHandler = new ConsoleHandler();
+        root.addHandler(testHandler);
+
+        Field initField = LoggingConfig.class.getDeclaredField("initialized");
+        initField.setAccessible(true);
+        boolean wasInitialized = initField.getBoolean(null);
+        initField.setBoolean(null, false);
+
+        try {
+            LoggingConfig.init("MM/dd");
+            assertEquals("MM/dd", getPattern(testHandler.getFormatter()));
+
+            LoggingConfig.init("yyyy");
+            assertEquals("MM/dd", getPattern(testHandler.getFormatter()));
+        } finally {
+            root.removeHandler(testHandler);
+            for (Handler h : original) {
+                root.addHandler(h);
+            }
+            initField.setBoolean(null, wasInitialized);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for LoggingConfig.init and useUniformFormatter
- document LoggingConfig tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e8323d1f8832a821b238569aa584b