### PR TITLE
Add tests for MapUtilities helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `MapUtilities.cloneMapOfMaps`, `cloneMapOfSets`, `dupe`, `mapOfEntries`, and `mapToString`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/MapUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/MapUtilitiesTest.java
@@ -2,8 +2,14 @@ package com.cedarsoftware.util;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
@@ -11,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -113,5 +121,134 @@ public class MapUtilitiesTest
         {
             assert e.getMessage().equals("garply");
         }
+    }
+
+    @Test
+    public void testCloneMapOfSetsMutable()
+    {
+        Map<String, Set<Integer>> original = new LinkedHashMap<>();
+        original.put("a", new LinkedHashSet<>(Arrays.asList(1, 2)));
+
+        Map<String, Set<Integer>> clone = MapUtilities.cloneMapOfSets(original, false);
+
+        assertEquals(original, clone);
+        assertNotSame(original, clone);
+        assertNotSame(original.get("a"), clone.get("a"));
+
+        clone.get("a").add(3);
+        assertFalse(original.get("a").contains(3));
+    }
+
+    @Test
+    public void testCloneMapOfSetsImmutable()
+    {
+        Map<String, Set<Integer>> original = new HashMap<>();
+        Set<Integer> set = new HashSet<>(Arrays.asList(5));
+        original.put("x", set);
+
+        Map<String, Set<Integer>> clone = MapUtilities.cloneMapOfSets(original, true);
+
+        assertThrows(UnsupportedOperationException.class, () -> clone.put("y", new HashSet<>()));
+        assertThrows(UnsupportedOperationException.class, () -> clone.get("x").add(6));
+
+        set.add(7);
+        assertTrue(clone.get("x").contains(7));
+    }
+
+    @Test
+    public void testCloneMapOfMapsMutable()
+    {
+        Map<String, Map<String, Integer>> original = new LinkedHashMap<>();
+        Map<String, Integer> inner = new LinkedHashMap<>();
+        inner.put("a", 1);
+        original.put("first", inner);
+
+        Map<String, Map<String, Integer>> clone = MapUtilities.cloneMapOfMaps(original, false);
+
+        assertEquals(original, clone);
+        assertNotSame(original, clone);
+        assertNotSame(inner, clone.get("first"));
+
+        clone.get("first").put("b", 2);
+        assertFalse(inner.containsKey("b"));
+    }
+
+    @Test
+    public void testCloneMapOfMapsImmutable()
+    {
+        Map<String, Map<String, Integer>> original = new HashMap<>();
+        Map<String, Integer> inner = new HashMap<>();
+        inner.put("n", 9);
+        original.put("num", inner);
+
+        Map<String, Map<String, Integer>> clone = MapUtilities.cloneMapOfMaps(original, true);
+
+        assertThrows(UnsupportedOperationException.class, () -> clone.put("z", new HashMap<>()));
+        assertThrows(UnsupportedOperationException.class, () -> clone.get("num").put("m", 10));
+
+        inner.put("p", 11);
+        assertTrue(clone.get("num").containsKey("p"));
+    }
+
+    @Test
+    public void testDupeMutable()
+    {
+        Map<Class<?>, Set<String>> original = new LinkedHashMap<>();
+        Set<String> vals = new LinkedHashSet<>(Arrays.asList("A"));
+        original.put(String.class, vals);
+
+        Map<Class<?>, Set<String>> clone = MapUtilities.dupe(original, false);
+
+        assertEquals(original, clone);
+        assertNotSame(original.get(String.class), clone.get(String.class));
+
+        clone.get(String.class).add("B");
+        assertFalse(original.get(String.class).contains("B"));
+    }
+
+    @Test
+    public void testDupeImmutable()
+    {
+        Map<Class<?>, Set<String>> original = new HashMap<>();
+        Set<String> set = new HashSet<>(Arrays.asList("X"));
+        original.put(Integer.class, set);
+
+        Map<Class<?>, Set<String>> clone = MapUtilities.dupe(original, true);
+
+        assertThrows(UnsupportedOperationException.class, () -> clone.put(String.class, new HashSet<>()));
+        assertThrows(UnsupportedOperationException.class, () -> clone.get(Integer.class).add("Y"));
+
+        set.add("Z");
+        assertFalse(clone.get(Integer.class).contains("Z"));
+    }
+
+    @Test
+    public void testMapOfEntries()
+    {
+        Map.Entry<String, Integer> e1 = new AbstractMap.SimpleEntry<>("a", 1);
+        Map.Entry<String, Integer> e2 = new AbstractMap.SimpleEntry<>("b", 2);
+
+        Map<String, Integer> map = MapUtilities.mapOfEntries(e1, e2);
+
+        assertEquals(2, map.size());
+        assertEquals(Integer.valueOf(1), map.get("a"));
+        assertThrows(UnsupportedOperationException.class, () -> map.put("c", 3));
+
+        assertThrows(NullPointerException.class, () -> MapUtilities.mapOfEntries(e1, null));
+    }
+
+    @Test
+    public void testMapToString()
+    {
+        Map<String, Integer> map = new LinkedHashMap<>();
+        map.put("x", 1);
+        map.put("y", 2);
+        assertEquals("{x=1, y=2}", MapUtilities.mapToString(map));
+
+        Map<String, Object> self = new HashMap<>();
+        self.put("self", self);
+        assertEquals("{self=(this Map)}", MapUtilities.mapToString(self));
+
+        assertEquals("{}", MapUtilities.mapToString(new HashMap<>()));
     }
 }


### PR DESCRIPTION
## Summary
- extend `MapUtilitiesTest` with coverage for clone, dupe and map formatting helpers
- note new tests in the changelog

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e83342d0c832ab9b2cdd6101733dc