### PR TITLE
Fix SQL date conversion timezone handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
+> * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.

--- a/src/main/java/com/cedarsoftware/util/convert/StringConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/StringConversions.java
@@ -403,11 +403,14 @@ final class StringConversions {
 
         // Handle ISO 8601 format
         try {
-            // Parse any ISO format (with or without zone) and convert to converter's timezone
-            Instant instant = dateStr.endsWith("Z") ?
-                    Instant.parse(dateStr) :
-                    ZonedDateTime.parse(dateStr).toInstant();
-            return java.sql.Date.valueOf(instant.atZone(converter.getOptions().getZoneId()).toLocalDate());
+            // Parse ISO date strings while respecting any supplied zone or offset.
+            if (dateStr.endsWith("Z")) {
+                return java.sql.Date.valueOf(
+                        Instant.parse(dateStr).atZone(ZoneOffset.UTC).toLocalDate());
+            }
+
+            ZonedDateTime zdt = ZonedDateTime.parse(dateStr);
+            return java.sql.Date.valueOf(zdt.toLocalDate());
         } catch (DateTimeParseException e) {
             // If not ISO 8601, try other formats using DateUtilities
             ZonedDateTime zdt = DateUtilities.parseDate(dateStr, converter.getOptions().getZoneId(), true);


### PR DESCRIPTION
## Summary
- ensure `StringConversions.toSqlDate` honors the timezone specified in ISO strings
- document the bug fix in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e932279f0832aa59884ee4456a516