### PR TITLE
Add SafeSimpleDateFormat.getDateFormat tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `SafeSimpleDateFormat.getDateFormat` static caching.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/SafeSimpleDateFormatGetDateFormatTest.java
+++ b/src/test/java/com/cedarsoftware/util/SafeSimpleDateFormatGetDateFormatTest.java
@@ -1,0 +1,31 @@
+package com.cedarsoftware.util;
+
+import java.text.SimpleDateFormat;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link SafeSimpleDateFormat#getDateFormat(String)}.
+ */
+public class SafeSimpleDateFormatGetDateFormatTest {
+
+    @Test
+    void testSameThreadReturnsCachedInstance() {
+        SimpleDateFormat df1 = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        SimpleDateFormat df2 = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        assertSame(df1, df2, "Expected cached formatter for same thread");
+    }
+
+    @Test
+    void testDifferentThreadsReturnDifferentInstances() throws Exception {
+        final SimpleDateFormat[] holder = new SimpleDateFormat[1];
+        Thread t = new Thread(() -> holder[0] = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd"));
+        t.start();
+        t.join();
+        SimpleDateFormat main = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        assertNotSame(main, holder[0], "Threads should not share cached formatter");
+    }
+}


### PR DESCRIPTION
## Summary
- test `SafeSimpleDateFormat.getDateFormat` caching behavior
- document the new test in `changelog.md`

## Testing
- `mvn -q test` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e83639320832aa890dbaafdcdebba