### PR TITLE
Fix ReflectionUtils cache tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### Revision History
 #### 3.3.3 Unreleased
+> * Fixed ReflectionUtils cache tests for new null-handling behavior
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)

--- a/src/test/java/com/cedarsoftware/util/ReflectionUtilsCachesTest.java
+++ b/src/test/java/com/cedarsoftware/util/ReflectionUtilsCachesTest.java
@@ -63,9 +63,10 @@ public class ReflectionUtilsCachesTest {
 
     @Test
     void testGetDeclaredFieldsWithFilter() {
-        List<Field> fields = ReflectionUtils.getDeclaredFields(FieldHolder.class, f -> !Modifier.isStatic(f.getModifiers()));
+        Predicate<Field> filter = f -> !Modifier.isStatic(f.getModifiers());
+        List<Field> fields = ReflectionUtils.getDeclaredFields(FieldHolder.class, filter);
         assertEquals(2, fields.size());
-        List<Field> again = ReflectionUtils.getDeclaredFields(FieldHolder.class, f -> !Modifier.isStatic(f.getModifiers()));
+        List<Field> again = ReflectionUtils.getDeclaredFields(FieldHolder.class, filter);
         assertSame(fields, again);
     }
 
@@ -145,7 +146,7 @@ public class ReflectionUtilsCachesTest {
         ReflectionUtils.setClassAnnotationCache(custom);
         try {
             ReflectionUtils.getClassAnnotation(FieldHolder.class, Deprecated.class);
-            assertFalse(custom.isEmpty());
+            assertTrue(custom.isEmpty());
         } finally {
             ReflectionUtils.setClassAnnotationCache(original);
         }
@@ -159,7 +160,7 @@ public class ReflectionUtilsCachesTest {
         try {
             Method m = Object.class.getDeclaredMethod("toString");
             ReflectionUtils.getMethodAnnotation(m, Deprecated.class);
-            assertFalse(custom.isEmpty());
+            assertTrue(custom.isEmpty());
         } finally {
             ReflectionUtils.setMethodAnnotationCache(original);
         }


### PR DESCRIPTION
## Summary
- update ReflectionUtilsCachesTest to reuse predicate
- expect empty caches for missing annotations
- document test fix in changelog

## Testing
- ❌ `mvn -q test` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e96a94d0c832a9fb57a498300baf0