### PR TITLE
Add tests for TrackingMap content replacement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `TrackingMap.replaceContents` and `TrackingMap.setWrappedMap`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/TrackingMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/TrackingMapTest.java
@@ -390,4 +390,73 @@ public class TrackingMapTest
         trackMap = new TrackingMap<>(new HashMap<>());
         assert trackMap.getWrappedMap() instanceof HashMap;
     }
+
+    @Test
+    public void testReplaceContentsMaintainsInstanceAndResetsState()
+    {
+        CaseInsensitiveMap<String, String> original = new CaseInsensitiveMap<>();
+        original.put("a", "alpha");
+        original.put("b", "bravo");
+        TrackingMap<String, String> tracking = new TrackingMap<>(original);
+        tracking.get("a");
+
+        Map<String, String> replacement = new HashMap<>();
+        replacement.put("c", "charlie");
+        replacement.put("d", "delta");
+
+        Map<String, String> before = tracking.getWrappedMap();
+        tracking.replaceContents(replacement);
+
+        assertSame(before, tracking.getWrappedMap());
+        assertEquals(2, tracking.size());
+        assertTrue(tracking.containsKey("c"));
+        assertTrue(tracking.containsKey("d"));
+        assertFalse(tracking.containsKey("a"));
+        assertTrue(tracking.keysUsed().isEmpty());
+    }
+
+    @Test
+    public void testReplaceContentsWithNullThrows()
+    {
+        TrackingMap<String, String> tracking = new TrackingMap<>(new HashMap<>());
+        try
+        {
+            tracking.replaceContents(null);
+            fail();
+        }
+        catch (IllegalArgumentException ignored)
+        { }
+    }
+
+    @Test
+    public void testSetWrappedMapDelegatesToReplaceContents()
+    {
+        Map<String, String> base = new HashMap<>();
+        base.put("x", "xray");
+        TrackingMap<String, String> tracking = new TrackingMap<>(base);
+
+        Map<String, String> newContents = new HashMap<>();
+        newContents.put("y", "yankee");
+        Map<String, String> before = tracking.getWrappedMap();
+
+        tracking.setWrappedMap(newContents);
+
+        assertSame(before, tracking.getWrappedMap());
+        assertEquals(1, tracking.size());
+        assertTrue(tracking.containsKey("y"));
+        assertTrue(tracking.keysUsed().isEmpty());
+    }
+
+    @Test
+    public void testSetWrappedMapNullThrows()
+    {
+        TrackingMap<String, String> tracking = new TrackingMap<>(new HashMap<>());
+        try
+        {
+            tracking.setWrappedMap(null);
+            fail();
+        }
+        catch (IllegalArgumentException ignored)
+        { }
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for `TrackingMap.replaceContents` and `setWrappedMap`
- document the new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e83aee2f4832abf80e508590fa83f