### PR TITLE
Add NodeVisit getter tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `Traverser.NodeVisit.getNode` and `getNodeClass`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/NodeVisitTest.java
+++ b/src/test/java/com/cedarsoftware/util/NodeVisitTest.java
@@ -1,0 +1,28 @@
+package com.cedarsoftware.util;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link Traverser.NodeVisit} basic getters.
+ */
+public class NodeVisitTest {
+
+    @Test
+    void testGetNode() {
+        Object node = new Object();
+        Traverser.NodeVisit visit = new Traverser.NodeVisit(node, Collections.emptyMap());
+        assertSame(node, visit.getNode());
+    }
+
+    @Test
+    void testGetNodeClass() {
+        String node = "test";
+        Traverser.NodeVisit visit = new Traverser.NodeVisit(node, Collections.emptyMap());
+        assertEquals(String.class, visit.getNodeClass());
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated test for Traverser.NodeVisit getters
- document the new test in the changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e83bdb6b0832a84f36e5675015183