### PR TITLE
Add JUnit test for Unsafe.allocateInstance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 > * `UniqueIdGenerator` uses `java.util.logging` and reduces CPU usage while waiting for the next millisecond
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added tests for `CaseInsensitiveString.chars`, `codePoints`, and `subSequence` plus deprecated `CaseInsensitiveSet` methods
+> * Added tests for `Unsafe.allocateInstance`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/UnsafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/UnsafeTest.java
@@ -1,0 +1,48 @@
+package com.cedarsoftware.util;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UnsafeTest {
+    static class Example {
+        static boolean ctorCalled = false;
+        int value = 5;
+
+        Example() {
+            ctorCalled = true;
+            value = 10;
+        }
+    }
+
+    @Test
+    void allocateInstanceBypassesConstructor() throws InvocationTargetException {
+        Unsafe unsafe = new Unsafe();
+        Example.ctorCalled = false;
+
+        Object obj = unsafe.allocateInstance(Example.class);
+        assertNotNull(obj);
+        assertTrue(obj instanceof Example);
+        Example ex = (Example) obj;
+        assertFalse(Example.ctorCalled, "constructor should not run");
+        assertEquals(0, ex.value, "field initialization should be skipped");
+    }
+
+    @Test
+    void allocateInstanceRejectsInterface() throws InvocationTargetException {
+        Unsafe unsafe = new Unsafe();
+        assertThrows(IllegalArgumentException.class, () -> unsafe.allocateInstance(Runnable.class));
+    }
+
+    @Test
+    void allocateInstanceRejectsNull() throws InvocationTargetException {
+        Unsafe unsafe = new Unsafe();
+        assertThrows(IllegalArgumentException.class, () -> unsafe.allocateInstance(null));
+    }
+}


### PR DESCRIPTION
## Summary
- add `UnsafeTest` covering allocateInstance usage and error cases
- document new test in `changelog.md`

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e83dac93c832abb5daf63d030db30