### PR TITLE
Fix TrackingMap tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 > * `SystemUtilities` logs shutdown hook failures, handles missing network interfaces and returns immutable address lists
   `TestUtil.fetchResource`, `MapUtilities.cloneMapOfSets`, and core cache methods.
 > * `TrackingMap` - `replaceContents()` replaces the misleading `setWrappedMap()` API. `keysUsed()` now returns an unmodifiable `Set<Object>` and `expungeUnused()` prunes stale keys.
+> * Fixed tests for `TrackingMap.replaceContents` and `setWrappedMap` to avoid tracking keys during verification
 > * `Traverser` supports lazy field collection, improved null-safe class skipping, and better error logging
 > * `Traverser` now ignores synthetic fields, preventing traversal into outer class references
 > * `Traverser` logs inaccessible fields at `Level.FINEST` instead of printing to STDERR

--- a/src/test/java/com/cedarsoftware/util/TrackingMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/TrackingMapTest.java
@@ -409,9 +409,9 @@ public class TrackingMapTest
 
         assertSame(before, tracking.getWrappedMap());
         assertEquals(2, tracking.size());
-        assertTrue(tracking.containsKey("c"));
-        assertTrue(tracking.containsKey("d"));
-        assertFalse(tracking.containsKey("a"));
+        assertTrue(tracking.getWrappedMap().containsKey("c"));
+        assertTrue(tracking.getWrappedMap().containsKey("d"));
+        assertFalse(tracking.getWrappedMap().containsKey("a"));
         assertTrue(tracking.keysUsed().isEmpty());
     }
 
@@ -443,7 +443,7 @@ public class TrackingMapTest
 
         assertSame(before, tracking.getWrappedMap());
         assertEquals(1, tracking.size());
-        assertTrue(tracking.containsKey("y"));
+        assertTrue(tracking.getWrappedMap().containsKey("y"));
         assertTrue(tracking.keysUsed().isEmpty());
     }
 


### PR DESCRIPTION
## Summary
- adjust TrackingMap tests so verifying map contents doesn't mark keys as read
- note test fix in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e9915f740832a931d2477d2e24ca5