### PR TITLE
Fix Unsafe instantiation to prevent crash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
   `TestUtil.fetchResource`, `MapUtilities.cloneMapOfSets`, and core cache methods.
 > * `TrackingMap` - `replaceContents()` replaces the misleading `setWrappedMap()` API. `keysUsed()` now returns an unmodifiable `Set<Object>` and `expungeUnused()` prunes stale keys.
 > * Fixed tests for `TrackingMap.replaceContents` and `setWrappedMap` to avoid tracking keys during verification
+> * `Unsafe` now obtains the sun.misc.Unsafe instance from the `theUnsafe` field instead of invoking its constructor, preventing JVM crashes during tests
 > * `Traverser` supports lazy field collection, improved null-safe class skipping, and better error logging
 > * `Traverser` now ignores synthetic fields, preventing traversal into outer class references
 > * `Traverser` logs inaccessible fields at `Level.FINEST` instead of printing to STDERR


### PR DESCRIPTION
## Summary
- use the `theUnsafe` field instead of invoking the private constructor
- validate interface/null input in `Unsafe.allocateInstance`
- note `Unsafe` fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e9b59eda8832aaa5c7637fc8a2648