### PR TITLE
Add tests for Compact*Set constructors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,7 @@
 > * `FastReader/FastWriter` - tests added to bring it to 100% Class, Method, Line, and Branch coverage.
 > * `FastByteArrayInputStream/FastByteArrayOutputStream` - tests added to bring it to 100% Class, Method, Line, and Branch coverage.
 > * `TrackingMap.setWrappedMap()` - added to allow the user to set the wrapped map to a different map.  This is useful for testing purposes.
+> * Added tests for CompactCIHashSet, CompactCILinkedSet and CompactLinkedSet constructors.
 #### 3.3.0 New Features and Improvements
 > * `CompactCIHashSet, CompactCILinkedSet, CompactLinkedSet, CompactCIHashMap, CompactCILinkedMap, CompactLinkedMap` are no longer deprecated. Subclassing `CompactMap` or `CompactSet` is a viable option if you need to serialize the derived class with libraries other than `json-io,` like Jackson, Gson, etc.
 > * Added `CharBuffer to Map,` `ByteBuffer to Map,` and vice-versa conversions.

--- a/src/test/java/com/cedarsoftware/util/CompactCIHashSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactCIHashSetTest.java
@@ -1,0 +1,33 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompactCIHashSetTest {
+
+    @Test
+    void defaultConstructorIsCaseInsensitive() {
+        CompactCIHashSet<String> set = new CompactCIHashSet<>();
+        assertTrue(set.isEmpty());
+        set.add("Foo");
+        assertTrue(set.contains("foo"));
+        assertTrue(set.contains("FOO"));
+
+        set.add("fOo");
+        assertEquals(1, set.size());
+    }
+
+    @Test
+    void collectionConstructorDeduplicates() {
+        List<String> values = Arrays.asList("one", "Two", "tWo");
+        CompactCIHashSet<String> set = new CompactCIHashSet<>(values);
+
+        assertEquals(2, set.size());
+        assertTrue(set.contains("ONE"));
+        assertTrue(set.contains("two"));
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/CompactCILinkedSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactCILinkedSetTest.java
@@ -1,0 +1,32 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompactCILinkedSetTest {
+
+    @Test
+    void defaultConstructorMaintainsOrder() {
+        CompactCILinkedSet<String> set = new CompactCILinkedSet<>();
+        set.add("A");
+        set.add("B");
+        set.add("C");
+        set.add("a"); // duplicate in different case
+
+        assertEquals(Arrays.asList("A", "B", "C"), new ArrayList<>(set));
+    }
+
+    @Test
+    void collectionConstructorHonorsOrder() {
+        List<String> src = Arrays.asList("x", "y", "X", "z");
+        CompactCILinkedSet<String> set = new CompactCILinkedSet<>(src);
+
+        assertEquals(Arrays.asList("x", "y", "z"), new ArrayList<>(set));
+        assertTrue(set.contains("X"));
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/CompactLinkedSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactLinkedSetTest.java
@@ -1,0 +1,32 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompactLinkedSetTest {
+
+    @Test
+    void defaultConstructorMaintainsOrder() {
+        CompactLinkedSet<String> set = new CompactLinkedSet<>();
+        set.add("first");
+        set.add("second");
+        set.add("third");
+        set.add("FIRST");
+
+        assertEquals(Arrays.asList("first", "second", "third"), new ArrayList<>(set));
+    }
+
+    @Test
+    void collectionConstructorHonorsOrder() {
+        List<String> src = Arrays.asList("a", "b", "A", "c");
+        CompactLinkedSet<String> set = new CompactLinkedSet<>(src);
+
+        assertEquals(Arrays.asList("a", "b", "c"), new ArrayList<>(set));
+        assertTrue(set.contains("A"));
+    }
+}


### PR DESCRIPTION
## Summary
- test `CompactCIHashSet` constructors
- test `CompactCILinkedSet` constructors
- test `CompactLinkedSet` constructors
- document test coverage in `changelog.md`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ea2633d98832a8373402994bc63f8