### PR TITLE
Add tests for AbstractConcurrentNullSafeMap entrySet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 > * `IOUtilities` improved: configurable timeouts, `inputStreamToBytes` throws `IOException` with size limit, offset bug fixed in `uncompressBytes`
 > * `MathUtilities` now validates inputs for empty arrays and null lists, fixes documentation, and improves numeric parsing performance
 > * Added unit tests for `GraphComparator` Java delta processor methods
+> * Added tests for `entrySet.contains()` and `entrySet.remove()` in `AbstractConcurrentNullSafeMap`
 > * `ReflectionUtils` cache size is configurable via the `reflection.utils.cache.size` system property, uses
 > * `StringUtilities.decode()` now returns `null` when invalid hexadecimal digits are encountered.
 > * `StringUtilities.getRandomString()` validates parameters and throws descriptive exceptions.

--- a/src/test/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMapEntrySetTest.java
+++ b/src/test/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMapEntrySetTest.java
@@ -1,0 +1,54 @@
+package com.cedarsoftware.util;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for entrySet contains() and remove() methods inherited from
+ * {@link AbstractConcurrentNullSafeMap}.
+ */
+class AbstractConcurrentNullSafeMapEntrySetTest {
+
+    @Test
+    void testEntrySetContains() {
+        ConcurrentHashMapNullSafe<String, String> map = new ConcurrentHashMapNullSafe<>();
+        map.put("a", "alpha");
+        map.put(null, "nullVal");
+        map.put("b", null);
+
+        Set<Map.Entry<String, String>> entries = map.entrySet();
+
+        assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("a", "alpha")));
+        assertTrue(entries.contains(new AbstractMap.SimpleEntry<>(null, "nullVal")));
+        assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("b", null)));
+        assertFalse(entries.contains(new AbstractMap.SimpleEntry<>("c", "gamma")));
+    }
+
+    @Test
+    void testEntrySetRemove() {
+        ConcurrentHashMapNullSafe<String, String> map = new ConcurrentHashMapNullSafe<>();
+        map.put("a", "alpha");
+        map.put(null, "nullVal");
+        map.put("b", null);
+
+        Set<Map.Entry<String, String>> entries = map.entrySet();
+
+        assertTrue(entries.remove(new AbstractMap.SimpleEntry<>("a", "alpha")));
+        assertFalse(map.containsKey("a"));
+
+        assertTrue(entries.remove(new AbstractMap.SimpleEntry<>(null, "nullVal")));
+        assertFalse(map.containsKey(null));
+
+        assertFalse(entries.remove(new AbstractMap.SimpleEntry<>("b", "beta")));
+        assertTrue(map.containsKey("b"));
+
+        assertTrue(entries.remove(new AbstractMap.SimpleEntry<>("b", null)));
+        assertFalse(map.containsKey("b"));
+    }
+}


### PR DESCRIPTION
## Summary
- test entrySet.contains and entrySet.remove on ConcurrentHashMapNullSafe
- document the new tests in the changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684ea3349c18832a8e9ad4123d06c566