### PR TITLE
Fix tests expecting case-insensitive CompactLinkedSet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Fixed `CompactLinkedSetTest` assertions to respect case-sensitive behavior.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/CompactLinkedSetTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactLinkedSetTest.java
@@ -18,7 +18,7 @@ class CompactLinkedSetTest {
         set.add("third");
         set.add("FIRST");
 
-        assertEquals(Arrays.asList("first", "second", "third"), new ArrayList<>(set));
+        assertEquals(Arrays.asList("first", "second", "third", "FIRST"), new ArrayList<>(set));
     }
 
     @Test
@@ -26,7 +26,7 @@ class CompactLinkedSetTest {
         List<String> src = Arrays.asList("a", "b", "A", "c");
         CompactLinkedSet<String> set = new CompactLinkedSet<>(src);
 
-        assertEquals(Arrays.asList("a", "b", "c"), new ArrayList<>(set));
+        assertEquals(Arrays.asList("a", "b", "A", "c"), new ArrayList<>(set));
         assertTrue(set.contains("A"));
     }
 }


### PR DESCRIPTION
## Summary
- update CompactLinkedSetTest expectations for case sensitive behavior
- note changes in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ea65262d8832aa3d07afc9cd603a8