### PR TITLE
Add missing ConcurrentList tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Added tests for ConcurrentList constructors and snapshot iterator.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentListAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentListAdditionalTest.java
@@ -1,0 +1,80 @@
+package com.cedarsoftware.util;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConcurrentListAdditionalTest {
+
+    @Test
+    void testConstructorWithSize() {
+        List<Integer> list = new ConcurrentList<>(10);
+        assertTrue(list.isEmpty(), "List should be empty after construction with capacity");
+        list.add(1);
+        assertEquals(1, list.size());
+    }
+
+    @Test
+    void testConstructorWrapsExistingList() {
+        List<String> backing = new ArrayList<>(Arrays.asList("a", "b"));
+        ConcurrentList<String> list = new ConcurrentList<>(backing);
+        list.add("c");
+        assertEquals(Arrays.asList("a", "b", "c"), backing);
+    }
+
+    @Test
+    void testConstructorRejectsNullList() {
+        assertThrows(IllegalArgumentException.class, () -> new ConcurrentList<>(null));
+    }
+
+    @Test
+    void testEqualsHashCodeAndToString() {
+        ConcurrentList<Integer> list1 = new ConcurrentList<>();
+        list1.addAll(Arrays.asList(1, 2, 3));
+        ConcurrentList<Integer> list2 = new ConcurrentList<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
+
+        assertEquals(list1, list2);
+        assertEquals(list1.hashCode(), list2.hashCode());
+        assertEquals(Arrays.asList(1, 2, 3).toString(), list1.toString());
+    }
+
+    @Test
+    void testListIteratorReturnsSnapshotStartingAtIndex() {
+        ConcurrentList<Integer> list = new ConcurrentList<>();
+        list.addAll(Arrays.asList(0, 1, 2, 3, 4));
+        ListIterator<Integer> iterator = list.listIterator(2);
+
+        list.add(5); // modify after iterator creation
+
+        List<Integer> snapshot = new ArrayList<>();
+        while (iterator.hasNext()) {
+            snapshot.add(iterator.next());
+            iterator.remove();
+        }
+
+        assertEquals(Arrays.asList(2, 3, 4), snapshot);
+        assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5), list);
+    }
+
+    @Test
+    void testWithReadLockVoid() throws Exception {
+        ConcurrentList<Integer> list = new ConcurrentList<>();
+        AtomicBoolean flag = new AtomicBoolean(false);
+        Method m = ConcurrentList.class.getDeclaredMethod("withReadLockVoid", Runnable.class);
+        m.setAccessible(true);
+        m.invoke(list, (Runnable) () -> flag.set(true));
+        assertTrue(flag.get());
+
+        m.invoke(list, (Runnable) () -> { throw new RuntimeException("boom"); });
+        list.add(1); // should not deadlock if lock released
+        assertEquals(1, list.size());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `ConcurrentListAdditionalTest` covering constructors, equality and iterator
- mention new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ea46baba4832a93c414200782ffce