### PR TITLE
Add tests for CollectionHandling empty wrappers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Added tests for `CollectionHandling` empty wrappers.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/CollectionHandlingEmptyTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/CollectionHandlingEmptyTest.java
@@ -1,0 +1,60 @@
+package com.cedarsoftware.util.convert;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CollectionHandlingEmptyTest {
+
+    @Test
+    void createEmptyCollection() {
+        List<String> source = Arrays.asList("a", "b");
+        Collection<String> result = (Collection<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getEmptyCollectionClass());
+        assertSame(Collections.emptyList(), result);
+        assertTrue(result.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> result.add("c"));
+    }
+
+    @Test
+    void createEmptyList() {
+        List<String> source = Arrays.asList("x", "y");
+        List<String> result = (List<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getEmptyListClass());
+        assertSame(Collections.emptyList(), result);
+        assertTrue(result.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> result.add("z"));
+    }
+
+    @Test
+    void createEmptySet() {
+        Set<String> source = new LinkedHashSet<>(Arrays.asList("1", "2"));
+        Set<String> result = (Set<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getEmptySetClass());
+        assertSame(Collections.emptySet(), result);
+        assertTrue(result.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> result.add("3"));
+    }
+
+    @Test
+    void createEmptySortedSet() {
+        SortedSet<String> source = new TreeSet<>(Arrays.asList("m", "n"));
+        SortedSet<String> result = (SortedSet<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getEmptySortedSetClass());
+        assertSame(Collections.emptySortedSet(), result);
+        assertTrue(result.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> result.add("o"));
+    }
+
+    @Test
+    void createEmptyNavigableSet() {
+        NavigableSet<String> source = new TreeSet<>(Arrays.asList("p", "q"));
+        NavigableSet<String> result = (NavigableSet<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getEmptyNavigableSetClass());
+        assertSame(Collections.emptyNavigableSet(), result);
+        assertTrue(result.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> result.add("r"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `CollectionHandlingEmptyTest` to cover the empty collection lambdas
- document new tests in the changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685067be9ed4832a85dff3dd2d311cb7