### PR TITLE
Add ClassLevel equals and hashCode test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Added unit tests for `Converter.ClassLevel` equality and hashing.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterClassLevelTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterClassLevelTest.java
@@ -1,0 +1,30 @@
+package com.cedarsoftware.util.convert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ConverterClassLevelTest {
+
+    @Test
+    void equalsAndHashCodeWithSameValues() {
+        Converter.ClassLevel first = new Converter.ClassLevel(String.class, 1);
+        Converter.ClassLevel second = new Converter.ClassLevel(String.class, 1);
+        assertThat(first).isEqualTo(second);
+        assertThat(first.hashCode()).isEqualTo(second.hashCode());
+    }
+
+    @Test
+    void equalsAndHashCodeWithDifferentValues() {
+        Converter.ClassLevel base = new Converter.ClassLevel(String.class, 1);
+        Converter.ClassLevel differentLevel = new Converter.ClassLevel(String.class, 2);
+        Converter.ClassLevel differentClass = new Converter.ClassLevel(Integer.class, 1);
+
+        assertThat(base).isNotEqualTo(differentLevel);
+        assertThat(base).isNotEqualTo(differentClass);
+        assertThat(base).isNotEqualTo("notClassLevel");
+
+        assertThat(base.hashCode()).isNotEqualTo(differentLevel.hashCode());
+        assertThat(base.hashCode()).isNotEqualTo(differentClass.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary
- test `Converter.ClassLevel` equality and hashCode
- document new test in the changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685068128cf8832a9fdc9caf50fa4fcc