### PR TITLE
Add tests for additional empty collection wrappers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 > * Added tests for `CollectionHandling` empty wrappers.
+> * Added tests for `CollectionsWrappers` empty collection classes.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/CollectionsWrappersTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/CollectionsWrappersTest.java
@@ -33,6 +33,14 @@ class CollectionsWrappersTest {
     }
 
     @Test
+    void testGetEmptyCollectionClass() {
+        Collection<Object> empty = Collections.emptyList();
+        assertSame(empty.getClass(), CollectionsWrappers.getEmptyCollectionClass());
+        assertTrue(empty.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> empty.add("x"));
+    }
+
+    @Test
     void testGetEmptySetClass() {
         Set<Object> empty = Collections.emptySet();
         assertSame(empty.getClass(), CollectionsWrappers.getEmptySetClass());

--- a/src/test/java/com/cedarsoftware/util/convert/WrappedCollectionsConversionTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/WrappedCollectionsConversionTest.java
@@ -102,6 +102,12 @@ class WrappedCollectionsConversionTest {
         assertInstanceOf(CollectionsWrappers.getEmptyListClass(), emptyList);
         assertTrue(emptyList.isEmpty());
         assertThrows(UnsupportedOperationException.class, () -> emptyList.add("newElement"));
+
+        // Convert to EmptyNavigableSet
+        NavigableSet<String> emptyNavigableSet = converter.convert(source, CollectionsWrappers.getEmptyNavigableSetClass());
+        assertInstanceOf(CollectionsWrappers.getEmptyNavigableSetClass(), emptyNavigableSet);
+        assertTrue(emptyNavigableSet.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> emptyNavigableSet.add("newElement"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- test `CollectionsWrappers.getEmptyCollectionClass`
- test converting to empty `NavigableSet`
- document new tests in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685069e22ba4832a82e57c63fb990282