### PR TITLE
Add test for values view

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
+> * Added tests for `values()` view of `ConcurrentNavigableMapNullSafe` to improve coverage.
 > * `withReadLockVoid()` now suppresses exceptions thrown by the provided `Runnable`.
   `ConcurrentHashMapNullSafe` for custom caches and generates unique parameter keys using fully qualified names.
 > * `Converter` - factory conversions map made immutable and legacy caching code removed

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeValuesTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeValuesTest.java
@@ -1,0 +1,51 @@
+package com.cedarsoftware.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the values() view of ConcurrentNavigableMapNullSafe.
+ */
+class ConcurrentNavigableMapNullSafeValuesTest {
+
+    @Test
+    void testValuesViewOperations() {
+        ConcurrentNavigableMapNullSafe<String, Integer> map = new ConcurrentNavigableMapNullSafe<>();
+        map.put("a", 1);
+        map.put("b", null);
+        map.put("c", 3);
+        map.put(null, 2);
+
+        Collection<Integer> values = map.values();
+
+        // Size and contains checks
+        assertEquals(4, values.size());
+        assertTrue(values.contains(1));
+        assertTrue(values.contains(null));
+        assertTrue(values.contains(2));
+        assertFalse(values.contains(5));
+
+        // Verify iteration order and unmasking
+        Iterator<Integer> it = values.iterator();
+        assertEquals(1, it.next());
+        assertNull(it.next());
+        assertEquals(3, it.next());
+        assertEquals(2, it.next());
+        assertFalse(it.hasNext());
+
+        // Remove using iterator and verify map is updated
+        it = values.iterator();
+        assertEquals(1, it.next());
+        it.remove();
+        assertFalse(map.containsKey("a"));
+        assertEquals(3, values.size());
+
+        // Clear the values view and ensure map is empty
+        values.clear();
+        assertTrue(map.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add `ConcurrentNavigableMapNullSafeValuesTest` to cover the `values()` view
- document test addition in changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68501a8a8ba0832abd1397cc87d1347f