### PR TITLE
Add tests for ConverterOptions custom options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
+> * `ConverterOptions` exposes its custom option map through `getCustomOptions()`.
 > * `withReadLockVoid()` now suppresses exceptions thrown by the provided `Runnable`.
   `ConcurrentHashMapNullSafe` for custom caches and generates unique parameter keys using fully qualified names.
 > * `Converter` - factory conversions map made immutable and legacy caching code removed

--- a/src/main/java/com/cedarsoftware/util/convert/ConverterOptions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/ConverterOptions.java
@@ -94,6 +94,13 @@ public interface ConverterOptions {
     default <T> T getCustomOption(String name) { return null; }
 
     /**
+     * Accessor for all custom options defined on this instance.
+     *
+     * @return the map of custom options
+     */
+    default Map<String, Object> getCustomOptions() { return new HashMap<>(); }
+
+    /**
      * @return TimeZone expected on the target when finished (only for types that support ZoneId or TimeZone).
      */
     default TimeZone getTimeZone() { return TimeZone.getTimeZone(this.getZoneId()); }

--- a/src/main/java/com/cedarsoftware/util/convert/DefaultConverterOptions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/DefaultConverterOptions.java
@@ -40,5 +40,8 @@ public class DefaultConverterOptions implements ConverterOptions {
     }
 
     @Override
+    public Map<String, Object> getCustomOptions() { return this.customOptions; }
+
+    @Override
     public Map<ConversionPair, Convert<?>> getConverterOverrides() { return this.converterOverrides; }
 }

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterOptionsCustomOptionTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterOptionsCustomOptionTest.java
@@ -1,0 +1,25 @@
+package com.cedarsoftware.util.convert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ConverterOptionsCustomOptionTest {
+
+    @Test
+    void defaultImplementationReturnsEmptyMap() {
+        ConverterOptions options = new ConverterOptions() { };
+        Map<String, Object> map = options.getCustomOptions();
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    void mapIsLiveForDefaultConverterOptions() {
+        DefaultConverterOptions options = new DefaultConverterOptions();
+        options.getCustomOptions().put("answer", 42);
+        assertThat(options.getCustomOption("answer")).isEqualTo(42);
+        assertThat(options.getCustomOptions()).containsEntry("answer", 42);
+    }
+}

--- a/userguide.md
+++ b/userguide.md
@@ -1906,6 +1906,7 @@ The static API is the easiest to use. It uses the default `ConverterOptions` obj
 public static APIs on the `com.cedarsoftware.util.Converter` class.
 
 The instance API allows you to create a `com.cedarsoftware.util.converter.Converter` instance with a custom `ConverterOptions` object.  If you add custom conversions, they will be used by the `Converter` instance.
+You can also store arbitrary settings in the options via `getCustomOptions()` and retrieve them later with `getCustomOption(name)`.
 You can create as many instances of the Converter as needed.  Often though, the static API is sufficient.
 
 **Collection Conversions:**


### PR DESCRIPTION
## Summary
- expose `getCustomOptions` in `ConverterOptions` API
- implement override in `DefaultConverterOptions`
- document new API
- test `getCustomOptions` behavior

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68506847c020832abf86447d99970f1e