### PR TITLE
Add test for ConvertWithTarget default method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Test added for `ConvertWithTarget.convert(Object, Converter)` default method.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/ConvertWithTargetTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConvertWithTargetTest.java
@@ -1,0 +1,34 @@
+package com.cedarsoftware.util.convert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConvertWithTargetTest {
+
+    @Test
+    void convertDelegatesToConvertWithTarget() {
+        class DummyConvert implements ConvertWithTarget<String> {
+            Object fromArg;
+            Converter converterArg;
+            Class<?> targetArg;
+            @Override
+            public String convertWithTarget(Object from, Converter converter, Class<?> target) {
+                this.fromArg = from;
+                this.converterArg = converter;
+                this.targetArg = target;
+                return "done";
+            }
+        }
+
+        Converter converter = new Converter(new DefaultConverterOptions());
+        DummyConvert dummy = new DummyConvert();
+
+        String result = dummy.convert("source", converter);
+
+        assertThat(result).isEqualTo("done");
+        assertThat(dummy.fromArg).isEqualTo("source");
+        assertThat(dummy.converterArg).isSameAs(converter);
+        assertThat(dummy.targetArg).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add ConvertWithTargetTest verifying delegation to `convertWithTarget`
- document test addition in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685068888110832ab6cf013babef4299