### PR TITLE
Fix empty collection conversion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
+> * Fixed conversions to empty wrapper collections preserving the specialized empty types
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.

--- a/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
@@ -74,6 +74,11 @@ public final class CollectionConversions {
             collection.add(element);
         }
 
+        // If the created collection already matches the target type, return it as is
+        if (targetType.isAssignableFrom(collection.getClass())) {
+            return (T) collection;
+        }
+
         // If wrapping is required, return the wrapped version
         if (requiresUnmodifiable) {
             return (T) getUnmodifiableCollection(collection);
@@ -107,6 +112,11 @@ public final class CollectionConversions {
                 element = collectionToCollection((Collection<?>) element, targetType);
             }
             targetCollection.add(element);
+        }
+
+        // If the created collection already matches the target type, return it as is
+        if (targetType.isAssignableFrom(targetCollection.getClass())) {
+            return targetCollection;
         }
 
         // If wrapping is required, return the wrapped version


### PR DESCRIPTION
## Summary
- prevent double wrapping in collection conversions
- document fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68506d349af4832ab24422fcc859f1c3