### PR TITLE
Fix ambiguous AssertJ test call

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 > * Explicitly set versions for `maven-resources-plugin`, `maven-install-plugin`, and `maven-deploy-plugin` to avoid Maven 4 compatibility warnings
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
+> * Fixed ambiguous AssertJ call in `ConverterOptionsCustomOptionTest`.
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterOptionsCustomOptionTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterOptionsCustomOptionTest.java
@@ -19,7 +19,7 @@ class ConverterOptionsCustomOptionTest {
     void mapIsLiveForDefaultConverterOptions() {
         DefaultConverterOptions options = new DefaultConverterOptions();
         options.getCustomOptions().put("answer", 42);
-        assertThat(options.getCustomOption("answer")).isEqualTo(42);
+        assertThat((Object) options.getCustomOption("answer")).isEqualTo(42);
         assertThat(options.getCustomOptions()).containsEntry("answer", 42);
     }
 }


### PR DESCRIPTION
## Summary
- cast object when asserting custom option to avoid ambiguous AssertJ overload
- document fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68506ec29054832aac9cc1521b0c7bb9