### PR TITLE
Add tests for empty wrappers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 > * Added unit tests for CollectionHandling empty and synchronized wrappers
+> * Added tests for Converter empty list and navigable set wrappers
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/convert/WrappedCollectionsConversionTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/WrappedCollectionsConversionTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class WrappedCollectionsConversionTest {
 
@@ -258,5 +259,27 @@ class WrappedCollectionsConversionTest {
         assertInstanceOf(Collection.class, result);
         assertTrue(result.contains(2));
         assertThrows(UnsupportedOperationException.class, () -> result.add("four"));
+    }
+
+    @Test
+    void testEmptyListSingleton() {
+        List<String> source = Arrays.asList("a", "b");
+        List<String> result1 = converter.convert(source, CollectionsWrappers.getEmptyListClass());
+        List<String> result2 = converter.convert(source, CollectionsWrappers.getEmptyListClass());
+
+        assertSame(Collections.emptyList(), result1);
+        assertSame(result1, result2);
+        assertThrows(UnsupportedOperationException.class, () -> result1.add("x"));
+    }
+
+    @Test
+    void testEmptyNavigableSetSingleton() {
+        NavigableSet<String> source = new TreeSet<>(Arrays.asList("x", "y"));
+        NavigableSet<String> result1 = converter.convert(source, CollectionsWrappers.getEmptyNavigableSetClass());
+        NavigableSet<String> result2 = converter.convert(source, CollectionsWrappers.getEmptyNavigableSetClass());
+
+        assertSame(Collections.emptyNavigableSet(), result1);
+        assertSame(result1, result2);
+        assertThrows(UnsupportedOperationException.class, () -> result1.add("z"));
     }
 }


### PR DESCRIPTION
## Summary
- add new tests covering empty list and navigable set conversions
- document the additional coverage in the changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6850722f6c9c832a99bef68b15750c88