### PR TITLE
Fix empty collection wrapper conversions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
 > * Fixed conversions to empty wrapper collections preserving the specialized empty types
+> * Converting to an empty wrapper now always returns the canonical singleton instance
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.

--- a/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
@@ -2,6 +2,13 @@ package com.cedarsoftware.util.convert;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
+import java.util.Collections;
+
+import static com.cedarsoftware.util.convert.CollectionsWrappers.getEmptyCollectionClass;
+import static com.cedarsoftware.util.convert.CollectionsWrappers.getEmptyListClass;
+import static com.cedarsoftware.util.convert.CollectionsWrappers.getEmptyNavigableSetClass;
+import static com.cedarsoftware.util.convert.CollectionsWrappers.getEmptySetClass;
+import static com.cedarsoftware.util.convert.CollectionsWrappers.getEmptySortedSetClass;
 
 import static com.cedarsoftware.util.CollectionUtilities.getSynchronizedCollection;
 import static com.cedarsoftware.util.CollectionUtilities.getUnmodifiableCollection;
@@ -42,6 +49,28 @@ public final class CollectionConversions {
 
     private CollectionConversions() { }
 
+    private static boolean isEmptyWrapper(Class<?> type) {
+        return getEmptyCollectionClass().isAssignableFrom(type)
+                || getEmptyListClass().isAssignableFrom(type)
+                || getEmptySetClass().isAssignableFrom(type)
+                || getEmptySortedSetClass().isAssignableFrom(type)
+                || getEmptyNavigableSetClass().isAssignableFrom(type);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Collection<?>> T emptyWrapper(Class<T> type) {
+        if (getEmptySetClass().isAssignableFrom(type)) {
+            return (T) Collections.emptySet();
+        }
+        if (getEmptySortedSetClass().isAssignableFrom(type)) {
+            return (T) Collections.emptySortedSet();
+        }
+        if (getEmptyNavigableSetClass().isAssignableFrom(type)) {
+            return (T) Collections.emptyNavigableSet();
+        }
+        return (T) Collections.emptyList();
+    }
+
     /**
      * Converts an array to a collection, supporting special collection types
      * and nested arrays.
@@ -53,6 +82,10 @@ public final class CollectionConversions {
      */
     @SuppressWarnings("unchecked")
     public static <T extends Collection<?>> T arrayToCollection(Object array, Class<T> targetType) {
+        if (isEmptyWrapper(targetType)) {
+            return emptyWrapper(targetType);
+        }
+
         int length = Array.getLength(array);
 
         // Determine if the target type requires unmodifiable behavior
@@ -98,6 +131,10 @@ public final class CollectionConversions {
      */
     @SuppressWarnings("unchecked")
     public static Object collectionToCollection(Collection<?> source, Class<?> targetType) {
+        if (isEmptyWrapper(targetType)) {
+            return emptyWrapper((Class<? extends Collection<?>>) targetType);
+        }
+
         // Determine if the target type requires unmodifiable behavior
         boolean requiresUnmodifiable = isUnmodifiable(targetType);
         boolean requiresSynchronized = isSynchronized(targetType);


### PR DESCRIPTION
## Summary
- avoid populating immutable empty collection wrappers
- return singleton instances when converting arrays or collections to empty wrappers
- document empty wrapper fix in changelog

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68507acf4164832aad109da682651676