### PR TITLE
Fix empty collection conversion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
 > * Fixed conversions to empty wrapper collections preserving the specialized empty types
+> * Converter correctly returns JDK singleton empty collections when source has content
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.

--- a/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
@@ -2,6 +2,7 @@ package com.cedarsoftware.util.convert;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
+import java.util.Collections;
 
 import static com.cedarsoftware.util.CollectionUtilities.getSynchronizedCollection;
 import static com.cedarsoftware.util.CollectionUtilities.getUnmodifiableCollection;
@@ -101,6 +102,22 @@ public final class CollectionConversions {
         // Determine if the target type requires unmodifiable behavior
         boolean requiresUnmodifiable = isUnmodifiable(targetType);
         boolean requiresSynchronized = isSynchronized(targetType);
+
+        // If the request is for one of the JDK's singleton empty collections,
+        // simply return the constant instance without attempting to populate it
+        if (targetType == CollectionsWrappers.getEmptyCollectionClass()
+                || targetType == CollectionsWrappers.getEmptyListClass()) {
+            return Collections.emptyList();
+        }
+        if (targetType == CollectionsWrappers.getEmptySetClass()) {
+            return Collections.emptySet();
+        }
+        if (targetType == CollectionsWrappers.getEmptySortedSetClass()) {
+            return Collections.emptySortedSet();
+        }
+        if (targetType == CollectionsWrappers.getEmptyNavigableSetClass()) {
+            return Collections.emptyNavigableSet();
+        }
 
         // Create a modifiable collection of the specified target type
         Collection<Object> targetCollection = (Collection<Object>) createCollection(source, targetType);


### PR DESCRIPTION
## Summary
- avoid populating singleton empty collection wrappers
- document fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68507c52d6a4832a83eec7e0d9f94b0a