### PR TITLE
Fix empty wrapper conversion for nested structures

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
 > * Fixed conversions to empty wrapper collections preserving the specialized empty types
+> * Converting nested collections or arrays to empty wrapper types now throws an `UnsupportedOperationException`
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.

--- a/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
@@ -83,6 +83,14 @@ public final class CollectionConversions {
     @SuppressWarnings("unchecked")
     public static <T extends Collection<?>> T arrayToCollection(Object array, Class<T> targetType) {
         if (isEmptyWrapper(targetType)) {
+            int length = Array.getLength(array);
+            for (int i = 0; i < length; i++) {
+                Object element = Array.get(array, i);
+                if (element instanceof Collection ||
+                        (element != null && element.getClass().isArray())) {
+                    throw new UnsupportedOperationException("Cannot convert nested structures to empty collection");
+                }
+            }
             return emptyWrapper(targetType);
         }
 
@@ -132,6 +140,12 @@ public final class CollectionConversions {
     @SuppressWarnings("unchecked")
     public static Object collectionToCollection(Collection<?> source, Class<?> targetType) {
         if (isEmptyWrapper(targetType)) {
+            for (Object element : source) {
+                if (element instanceof Collection ||
+                        (element != null && element.getClass().isArray())) {
+                    throw new UnsupportedOperationException("Cannot convert nested structures to empty collection");
+                }
+            }
             return emptyWrapper((Class<? extends Collection<?>>) targetType);
         }
 


### PR DESCRIPTION
## Summary
- throw `UnsupportedOperationException` when converting nested collections or arrays to empty collection wrappers
- document the new behavior in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850accf807c832a8adf8492f0c8f72c