### PR TITLE
Add tests for checked list and collection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### Revision History
 #### 3.3.3 Unreleased
 > * Added tests for checked NavigableSet and SortedSet creation
+> * Added tests for checked List and Collection creation
 > * Fixed ReflectionUtils cache tests for new null-handling behavior
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.

--- a/src/test/java/com/cedarsoftware/util/convert/CollectionHandlingCheckedTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/CollectionHandlingCheckedTest.java
@@ -29,4 +29,26 @@ class CollectionHandlingCheckedTest {
         assertTrue(result.contains("z"));
         assertThrows(ClassCastException.class, () -> ((SortedSet) result).add(2));
     }
+
+    @Test
+    void createCheckedList() {
+        List<String> source = Arrays.asList("a", "b");
+        List<String> result = (List<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getCheckedListClass());
+        assertInstanceOf(CollectionsWrappers.getCheckedListClass(), result);
+        result.add("c");
+        assertTrue(result.contains("c"));
+        assertThrows(ClassCastException.class, () -> ((List) result).add(1));
+    }
+
+    @Test
+    void createCheckedCollection() {
+        Collection<String> source = new ArrayList<>(Arrays.asList("x", "y"));
+        Collection<String> result = (Collection<String>) CollectionHandling.createCollection(source,
+                CollectionsWrappers.getCheckedCollectionClass());
+        assertInstanceOf(CollectionsWrappers.getCheckedCollectionClass(), result);
+        result.add("z");
+        assertTrue(result.contains("z"));
+        assertThrows(ClassCastException.class, () -> ((Collection) result).add(2));
+    }
 }


### PR DESCRIPTION
## Summary
- cover `getCheckedListClass` and `getCheckedCollectionClass` handlers
- note new tests in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6850aec1998c832aaf236dcf6dc09ea5