### PR TITLE
Remove redundant empty-collection checks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -50,6 +50,7 @@
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 > * Added unit tests for CollectionHandling empty and synchronized wrappers
 > * Added tests for Converter empty list and navigable set wrappers
+> * Removed redundant empty collection checks in `CollectionConversions.collectionToCollection`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
@@ -153,22 +153,6 @@ public final class CollectionConversions {
         boolean requiresUnmodifiable = isUnmodifiable(targetType);
         boolean requiresSynchronized = isSynchronized(targetType);
 
-        // If the request is for one of the JDK's singleton empty collections,
-        // simply return the constant instance without attempting to populate it
-        if (targetType == CollectionsWrappers.getEmptyCollectionClass()
-                || targetType == CollectionsWrappers.getEmptyListClass()) {
-            return Collections.emptyList();
-        }
-        if (targetType == CollectionsWrappers.getEmptySetClass()) {
-            return Collections.emptySet();
-        }
-        if (targetType == CollectionsWrappers.getEmptySortedSetClass()) {
-            return Collections.emptySortedSet();
-        }
-        if (targetType == CollectionsWrappers.getEmptyNavigableSetClass()) {
-            return Collections.emptyNavigableSet();
-        }
-
         // Create a modifiable collection of the specified target type
         Collection<Object> targetCollection = (Collection<Object>) createCollection(source, targetType);
 


### PR DESCRIPTION
## Summary
- delete redundant empty collection checks in `collectionToCollection`
- document the cleanup in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850b8c14444832ab6088855594789e2