### PR TITLE
Add test for ConverterOptions default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
 > * `withReadLockVoid()` now suppresses exceptions thrown by the provided `Runnable`.
+> * Added test for `ConverterOptions.getCustomOption` default implementation
   `ConcurrentHashMapNullSafe` for custom caches and generates unique parameter keys using fully qualified names.
 > * `Converter` - factory conversions map made immutable and legacy caching code removed
 > * `DateUtilities` uses `BigDecimal` for fractional second conversion, preventing rounding errors with high precision input

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterOptionsCustomOptionTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterOptionsCustomOptionTest.java
@@ -9,6 +9,13 @@ import org.junit.jupiter.api.Test;
 class ConverterOptionsCustomOptionTest {
 
     @Test
+    void defaultGetCustomOptionReturnsNull() {
+        ConverterOptions options = new ConverterOptions() { };
+        Object value = options.getCustomOption("missing");
+        assertThat(value).isNull();
+    }
+
+    @Test
     void defaultImplementationReturnsEmptyMap() {
         ConverterOptions options = new ConverterOptions() { };
         Map<String, Object> map = options.getCustomOptions();


### PR DESCRIPTION
## Summary
- test default return from `ConverterOptions.getCustomOption`
- document the added test in the changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850ba686888832aaff66f62c3345ed4