### PR TITLE
Add tests for collection conversion support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### Revision History
 #### 3.3.3 Unreleased
+> * Added tests for Converter.isCollectionConversionSupported
 > * Added tests for checked NavigableSet and SortedSet creation
 > * Added tests for checked List and Collection creation
 > * Fixed ReflectionUtils cache tests for new null-handling behavior

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterCollectionSupportTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterCollectionSupportTest.java
@@ -1,0 +1,40 @@
+package com.cedarsoftware.util.convert;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConverterCollectionSupportTest {
+
+    private enum Day { MONDAY, TUESDAY }
+
+    @Test
+    void enumTargetSupportedFromCollection() {
+        assertTrue(Converter.isCollectionConversionSupported(List.class, Day.class));
+    }
+
+    @Test
+    void enumSetSourceSupportedToArray() {
+        assertTrue(Converter.isCollectionConversionSupported(EnumSet.class, String[].class));
+    }
+
+    @Test
+    void collectionSourceSupportedToCollection() {
+        assertTrue(Converter.isCollectionConversionSupported(List.class, Set.class));
+    }
+
+    @Test
+    void arrayToArrayWhenTargetNotCollection() {
+        assertTrue(Converter.isCollectionConversionSupported(String[].class, Integer[].class));
+    }
+
+    @Test
+    void unsupportedTypesReturnFalse() {
+        assertFalse(Converter.isCollectionConversionSupported(String.class, Integer.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `Converter.isCollectionConversionSupported`
- document the new tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850bb918f24832ab0dc521ee8db2111