### PR TITLE
Fix empty collection conversions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
 > * Fixed conversions to empty wrapper collections preserving the specialized empty types
 > * Converting nested collections or arrays to empty wrapper types now throws an `UnsupportedOperationException`
+> * Converting non-empty collections or arrays directly to empty wrappers now returns the canonical empty instance
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.

--- a/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
+++ b/src/main/java/com/cedarsoftware/util/convert/CollectionConversions.java
@@ -64,6 +64,11 @@ public final class CollectionConversions {
         // Create the appropriate collection using CollectionHandling
         Collection<Object> collection = (Collection<Object>) createCollection(array, targetType);
 
+        // If the target represents an empty collection, return it immediately
+        if (isEmptyCollection(targetType)) {
+            return (T) collection;
+        }
+
         // Populate the collection with array elements
         for (int i = 0; i < length; i++) {
             Object element = Array.get(array, i);
@@ -108,6 +113,11 @@ public final class CollectionConversions {
         // Create a modifiable collection of the specified target type
         Collection<Object> targetCollection = (Collection<Object>) createCollection(source, targetType);
 
+        // If the target represents an empty collection, return it without population
+        if (isEmptyCollection(targetType)) {
+            return targetCollection;
+        }
+
         // Populate the target collection, handling nested collections recursively
         for (Object element : source) {
             if (element instanceof Collection) {
@@ -130,5 +140,17 @@ public final class CollectionConversions {
             return getSynchronizedCollection(targetCollection);
         }
         return targetCollection;
+    }
+
+    /**
+     * Determines if the specified target type represents one of the empty
+     * collection wrapper classes.
+     */
+    private static boolean isEmptyCollection(Class<?> targetType) {
+        return CollectionsWrappers.getEmptyCollectionClass().isAssignableFrom(targetType)
+                || CollectionsWrappers.getEmptyListClass().isAssignableFrom(targetType)
+                || CollectionsWrappers.getEmptySetClass().isAssignableFrom(targetType)
+                || CollectionsWrappers.getEmptySortedSetClass().isAssignableFrom(targetType)
+                || CollectionsWrappers.getEmptyNavigableSetClass().isAssignableFrom(targetType);
     }
 }


### PR DESCRIPTION
## Summary
- handle empty collection wrapper classes during conversion
- document behavior in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850c2c6d224832aaaa78143cf4f627c