### PR TITLE
Add test for unsupported conversion caching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 > * Added unit tests for CollectionHandling empty and synchronized wrappers
 > * Added tests for Converter empty list and navigable set wrappers
+> * Added test that cached unsupported conversions return null
 > * Removed redundant empty collection checks in `CollectionConversions.arrayToCollection` and `collectionToCollection`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterUnsupportedTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterUnsupportedTest.java
@@ -1,0 +1,23 @@
+package com.cedarsoftware.util.convert;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConverterUnsupportedTest {
+
+    @Test
+    void cachedUnsupportedReturnsNull() {
+        Converter converter1 = new Converter(new DefaultConverterOptions());
+        assertThrows(IllegalArgumentException.class,
+                () -> converter1.convert(new HashMap<>(), Map.class));
+
+        Converter converter2 = new Converter(new DefaultConverterOptions());
+        assertFalse(converter2.isSimpleTypeConversionSupported(Map.class, Map.class));
+        Map<?, ?> result = converter2.convert(new HashMap<>(), Map.class);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
## Summary
- test that cached unsupported conversions return null
- document the new test in `changelog.md`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850c38c1e94832aa4d2261528d6c4fe