### PR TITLE
Fix unsupported conversion caching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 > * Fixed ReflectionUtils cache tests for new null-handling behavior
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
+> * `Converter` now caches unsupported conversions to avoid repeated exceptions
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs

--- a/src/main/java/com/cedarsoftware/util/convert/Converter.java
+++ b/src/main/java/com/cedarsoftware/util/convert/Converter.java
@@ -1299,6 +1299,8 @@ public final class Converter {
             return (T) conversionMethod.convert(from, this, toType);
         }
 
+        // Cache unsupported conversions so later attempts simply return null
+        cacheConverter(sourceType, toType, UNSUPPORTED);
         throw new IllegalArgumentException("Unsupported conversion, source type [" + name(from) +
                 "] target type '" + getShortName(toType) + "'");
     }


### PR DESCRIPTION
## Summary
- cache missing conversions inside `Converter.convert`
- document caching behavior in `changelog.md`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850c71728cc832a94d5dc3ec0829fc8