### PR TITLE
Fix CompactMap custom map type test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,7 @@
 > * Added test that cached unsupported conversions return null
 > * Added test verifying cached unsupported converters are reused on subsequent conversions
 > * Removed redundant empty collection checks in `CollectionConversions.arrayToCollection` and `collectionToCollection`
+> * Custom map types under `com.cedarsoftware.io` allowed for `CompactMap`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -266,7 +266,8 @@ public class CompactMap<K, V> implements Map<K, V> {
     private static final Set<String> ALLOWED_MAP_PACKAGES = new HashSet<>(Arrays.asList(
             "java.util",
             "java.util.concurrent",
-            "com.cedarsoftware.util"));
+            "com.cedarsoftware.util",
+            "com.cedarsoftware.io"));
     private static final String INNER_MAP_TYPE = "innerMapType";
     private static final TemplateClassLoader templateClassLoader = new TemplateClassLoader(ClassUtilities.getClassLoader(CompactMap.class));
     private static final Map<String, ReentrantLock> CLASS_LOCKS = new ConcurrentHashMap<>();

--- a/src/test/java/com/cedarsoftware/io/CompactMapCustomTypeTest.java
+++ b/src/test/java/com/cedarsoftware/io/CompactMapCustomTypeTest.java
@@ -1,0 +1,52 @@
+package com.cedarsoftware.io;
+
+import java.util.Map;
+
+import com.cedarsoftware.util.CompactMap;
+import com.cedarsoftware.util.ReflectionUtils;
+import com.cedarsoftware.util.TypeHolder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompactMapCustomTypeTest {
+
+    @Test
+    void testCompactMapWithCustomMapType() {
+        CompactMap<String, String> map = CompactMap.<String, String>builder()
+                .caseSensitive(true)
+                .compactSize(42)
+                .singleValueKey("code")
+                .noOrder()
+                .mapType(CustomTestMap.class)
+                .build();
+
+        map.put("one", "First");
+        map.put("two", "Second");
+        map.put("three", "Third");
+
+        for (int i = 0; i < 50; i++) {
+            map.put("key" + i, "value" + i);
+        }
+
+        Map<?, ?> newMap = (Map<?, ?>) ReflectionUtils.call(map, "getNewMap");
+        assertInstanceOf(CustomTestMap.class, newMap, "New map should be a CustomTestMap");
+
+        String json = JsonIo.toJson(map, null);
+        CompactMap<String, String> restored = JsonIo.toJava(json, null)
+                .asType(new TypeHolder<CompactMap<String, String>>(){});
+
+        assertEquals(53, restored.size());
+        assertEquals("First", restored.get("one"));
+        assertEquals("Second", restored.get("two"));
+        assertEquals("Third", restored.get("three"));
+        assertEquals(false, ReflectionUtils.call(restored, "isCaseInsensitive"));
+        assertEquals(42, ReflectionUtils.call(restored, "compactSize"));
+        assertEquals("code", ReflectionUtils.call(restored, "getSingleValueKey"));
+
+        Map<?, ?> restoredNewMap = (Map<?, ?>) ReflectionUtils.call(restored, "getNewMap");
+        assertInstanceOf(CustomTestMap.class, restoredNewMap, "Restored map should create CustomTestMap instances");
+    }
+}
+

--- a/src/test/java/com/cedarsoftware/io/CustomTestMap.java
+++ b/src/test/java/com/cedarsoftware/io/CustomTestMap.java
@@ -1,0 +1,10 @@
+package com.cedarsoftware.io;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Simple map implementation used for testing custom map types with CompactMap.
+ */
+public class CustomTestMap<K,V> extends LinkedHashMap<K,V> {
+}
+


### PR DESCRIPTION
## Summary
- permit `com.cedarsoftware.io` maps when building a `CompactMap`
- add a simple `CustomTestMap` for testing
- test using `CompactMap` with a custom map implementation
- document change in `changelog.md`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850d3c5d108832a8d9a49765af46397