### PR TITLE
Update docs to prefer prebuilt compact collections

### DIFF
--- a/src/main/java/com/cedarsoftware/util/CompactMap.java
+++ b/src/main/java/com/cedarsoftware/util/CompactMap.java
@@ -45,9 +45,13 @@ import java.util.stream.Collectors;
  * to minimize memory usage while maintaining excellent performance.
  *
  * <h2>Creating a CompactMap</h2>
- * There are two primary ways to create a CompactMap:
+ * Most applications should create one of the provided subclasses
+ * ({@link CompactLinkedMap}, {@link CompactCIHashMap}, or
+ * {@link CompactCILinkedMap}) or extend {@code CompactMap} and override
+ * its configuration methods. The builder pattern can also be used for
+ * custom configurations when running on a JDK.
  *
- * <h3>1. Using the Builder Pattern (Recommended)</h3>
+ * <h3>Using the Builder Pattern (requires JDK)</h3>
  * <pre>{@code
  * // Create a case-insensitive, sorted CompactMap
  * CompactMap<String, Object> map = CompactMap.<String, Object>builder()
@@ -2189,6 +2193,8 @@ public class CompactMap<K, V> implements Map<K, V> {
      * Returns a builder for creating customized CompactMap instances.
      * <p>
      * For detailed configuration options and examples, see {@link Builder}.
+     * This API generates subclasses at runtime and therefore requires
+     * the JDK compiler tools to be present.
      * <p>
      * Note: When method chaining directly from builder(), you may need to provide
      * a type witness to help type inference:

--- a/src/main/java/com/cedarsoftware/util/CompactSet.java
+++ b/src/main/java/com/cedarsoftware/util/CompactSet.java
@@ -23,17 +23,19 @@ import java.util.Comparator;
  * </p>
  *
  * <h2>Creating a CompactSet</h2>
+ * Typically you will create one of the provided subclasses
+ * ({@link CompactLinkedSet}, {@link CompactCIHashSet}, or
+ * {@link CompactCILinkedSet}) or extend {@code CompactSet} with your own
+ * configuration. The builder pattern is available for advanced cases
+ * when running on a JDK.
  * <pre>{@code
- * // Create a case-insensitive, sorted CompactSet
- * CompactSet<String> set = CompactSet.<String>builder()
+ * CompactLinkedSet<String> set = new CompactLinkedSet<>();
+ * set.add("hello");
+ *
+ * // Builder pattern (requires JDK)
+ * CompactSet<String> custom = CompactSet.<String>builder()
  *     .caseSensitive(false)
  *     .sortedOrder()
- *     .compactSize(80)
- *     .build();
- *
- * // Create a CompactSet with insertion ordering
- * CompactSet<String> ordered = CompactSet.<String>builder()
- *     .insertionOrder()
  *     .build();
  * }</pre>
  *
@@ -234,6 +236,8 @@ public class CompactSet<E> implements Set<E> {
 
     /**
      * Returns a builder for creating customized CompactSet instances.
+     * This API generates subclasses at runtime and therefore requires
+     * the JDK compiler tools to be present.
      *
      * @param <E> the type of elements in the set
      * @return a new Builder instance

--- a/userguide.md
+++ b/userguide.md
@@ -17,19 +17,24 @@ A memory-efficient `Set` implementation that internally uses `CompactMap`. This 
 - Customizable compact size threshold
 - Memory-efficient internal storage
 
+Most applications simply instantiate one of the provided subclasses
+such as `CompactCIHashSet`, `CompactCILinkedSet`, or
+`CompactLinkedSet`. You may also subclass `CompactSet` yourself to
+hard-code your preferred options. The builder API is available for
+advanced use cases when running on a full JDK.
+
 ### Usage Examples
 
 ```java
-// Create a case-insensitive, sorted CompactSet
+// Most common usage: instantiate a provided subclass
+CompactLinkedSet<String> linked = new CompactLinkedSet<>();
+linked.add("hello");
+
+// Advanced: build a custom CompactSet (requires JDK)
 CompactSet<String> set = CompactSet.<String>builder()
     .caseSensitive(false)
     .sortedOrder()
     .compactSize(50)
-    .build();
-
-// Create a CompactSet with insertion ordering
-CompactSet<String> ordered = CompactSet.<String>builder()
-    .insertionOrder()
     .build();
 ```
 
@@ -443,24 +448,30 @@ A memory-efficient Map implementation that dynamically adapts its internal stora
 
 ### Key Features
 - Dynamic storage optimization based on size
-- Builder pattern for creation and configuration
+- Optional builder API for advanced configuration (requires JDK)
 - Support for case-sensitive/insensitive String keys
 - Configurable ordering (sorted, reverse, insertion, unordered)
 - Custom backing map implementations
 - Thread-safe when wrapped with Collections.synchronizedMap()
 - Full Map interface implementation
 
+Most developers will instantiate one of the pre-built subclasses such
+as `CompactLinkedMap`, `CompactCIHashMap`, or `CompactCILinkedMap`. You
+can also extend `CompactMap` and override its configuration methods to
+create your own variant. The builder API should generally be reserved
+for situations where you know you are running on a full JDK.
+
 ### Usage Examples
 
 **Basic Usage:**
 ```java
-// Simple creation
-CompactMap<String, Object> map = new CompactMap<>();
-map.put("key", "value");
+// Using a predefined subclass
+CompactLinkedMap<String, Object> linked = new CompactLinkedMap<>();
+linked.put("key", "value");
 
 // Create from existing map
 Map<String, Object> source = new HashMap<>();
-CompactMap<String, Object> copy = new CompactMap<>(source);
+CompactLinkedMap<String, Object> copy = new CompactLinkedMap<>(source);
 ```
 
 **Builder Pattern (requires execution on JDK):**


### PR DESCRIPTION
## Summary
- recommend using provided subclasses or your own subclasses
- clarify JDK requirement for builder APIs in CompactMap and CompactSet
- deemphasize builder usage in userguide

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6851f6946e28832a9500c424ad3f42fb