### PR TITLE
Add entry and keySet iterator tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@
 > * Added Javadoc for several public APIs where it was missing.  Should be 100% now.
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 > * Custom map types under `com.cedarsoftware.io` allowed for `CompactMap`
+> * Added tests for `AbstractConcurrentNullSafeMap` entry equality and key set iterator removal
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMapEntrySetTest.java
+++ b/src/test/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMapEntrySetTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for entrySet contains() and remove() methods inherited from
@@ -50,5 +51,23 @@ class AbstractConcurrentNullSafeMapEntrySetTest {
 
         assertTrue(entries.remove(new AbstractMap.SimpleEntry<>("b", null)));
         assertFalse(map.containsKey("b"));
+    }
+
+    @Test
+    void testEntrySetEntryEqualityHashAndToString() {
+        ConcurrentHashMapNullSafe<String, String> map = new ConcurrentHashMapNullSafe<>();
+        map.put("a", "alpha");
+        map.put(null, "nullVal");
+        map.put("b", null);
+
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            Map.Entry<String, String> other = new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue());
+            assertTrue(entry.equals(other));
+            assertEquals(other.hashCode(), entry.hashCode());
+
+            String expected = entry.getKey() + "=" + entry.getValue();
+            assertEquals(expected, entry.toString());
+            assertFalse(entry.toString().contains("@"));
+        }
     }
 }

--- a/src/test/java/com/cedarsoftware/util/ConcurrentHashMapNullSafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentHashMapNullSafeTest.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -357,6 +358,26 @@ class ConcurrentHashMapNullSafeTest {
         keys.remove(null);
         assertFalse(map.containsKey(null));
         assertEquals(1, map.size());
+    }
+
+    @Test
+    void testKeySetIteratorRemove() {
+        map.put("one", 1);
+        map.put("two", 2);
+        map.put(null, 100);
+
+        Iterator<String> it = map.keySet().iterator();
+        int expectedSize = 3;
+        while (it.hasNext()) {
+            String key = it.next();
+            it.remove();
+            expectedSize--;
+            assertFalse(map.containsKey(key));
+            assertEquals(expectedSize, map.size());
+        }
+
+        assertTrue(map.isEmpty());
+        assertTrue(map.entrySet().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- test equality, hash, and toString for entries returned from AbstractConcurrentNullSafeMap
- verify remove through keySet iterator updates map
- document new tests in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852124c58d4832aa530bd923858b195