### PR TITLE
Fix overlapping member variable test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 > * `StringUtilities.decode()` now returns `null` when invalid hexadecimal digits are encountered.
 > * `StringUtilities.getRandomString()` validates parameters and throws descriptive exceptions.
 > * `StringUtilities.count()` uses a reliable substring search algorithm.
+> * Updated inner-class JSON test to match removal of synthetic `this$` fields.
 > * `StringUtilities.hashCodeIgnoreCase()` updates locale compatibility when the default locale changes.
 > * `StringUtilities.commaSeparatedStringToSet()` returns a mutable empty set using `LinkedHashSet`.
 > * `StringUtilities` adds `snakeToCamel`, `camelToSnake`, `isNumeric`, `repeat`, `reverse`, `padLeft`, and `padRight` helpers.

--- a/src/test/java/com/cedarsoftware/io/OverlappingMemberVariableNamesTest.java
+++ b/src/test/java/com/cedarsoftware/io/OverlappingMemberVariableNamesTest.java
@@ -1,0 +1,48 @@
+package com.cedarsoftware.io;
+
+import com.cedarsoftware.util.TypeHolder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Ensure that inner class fields are properly serialized when the inner and outer
+ * classes share member names. The JSON output should no longer include the
+ * synthetic 'this$' reference after record support changes.
+ */
+public class OverlappingMemberVariableNamesTest {
+
+    static class Outer {
+        private String name;
+        private Inner foo;
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public Inner getFoo() { return foo; }
+        public void setFoo(Inner foo) { this.foo = foo; }
+
+        class Inner {
+            private String name;
+            public String getName() { return name; }
+            public void setName(String name) { this.name = name; }
+        }
+    }
+
+    @Test
+    public void testNestedWithSameMemberName() {
+        Outer outer = new Outer();
+        outer.setName("Joe Outer");
+
+        Outer.Inner inner = outer.new Inner();
+        outer.setFoo(inner);
+        outer.getFoo().setName("Jane Inner");
+
+        String json = JsonIo.toJson(outer, null);
+        assertFalse(json.contains("this$"), "Outer reference should not be serialized");
+
+        Outer x = JsonIo.toJava(json, null).asType(TypeHolder.of(Outer.class));
+
+        assertEquals("Joe Outer", x.getName());
+        assertEquals("Jane Inner", x.getFoo().getName());
+    }
+}


### PR DESCRIPTION
## Summary
- add test for inner-class member serialization
- update changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685215f22508832aaeb8933a98a24633