### PR TITLE
Add tests for safelyIgnoreException

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
 > * JUnits added for all public APIs that did not have them (no longer relying on json-io to "cover" them). Should be 100% now.
 > * Custom map types under `com.cedarsoftware.io` allowed for `CompactMap`
 > * Added tests for `AbstractConcurrentNullSafeMap` entry equality and key set iterator removal
+> * Added JUnit tests for `ExceptionUtilities.safelyIgnoreException`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ExceptionUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/ExceptionUtilitiesTest.java
@@ -4,12 +4,15 @@ package com.cedarsoftware.util;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Ken Partlow
@@ -65,5 +68,29 @@ public class ExceptionUtilitiesTest
             assert t != e;
             assert t.getMessage().contains("Unable to parse: foo");
         }
+    }
+
+    @Test
+    void testCallableExceptionReturnsDefault() {
+        String result = ExceptionUtilities.safelyIgnoreException(() -> {
+            throw new Exception("fail");
+        }, "default");
+        assertEquals("default", result);
+    }
+
+    @Test
+    void testCallableSuccessReturnsValue() {
+        String result = ExceptionUtilities.safelyIgnoreException(() -> "value", "default");
+        assertEquals("value", result);
+    }
+
+    @Test
+    void testRunnableExceptionIgnored() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+        ExceptionUtilities.safelyIgnoreException((Runnable) () -> {
+            ran.set(true);
+            throw new RuntimeException("boom");
+        });
+        assertTrue(ran.get());
     }
 }


### PR DESCRIPTION
## Summary
- add missing JUnit tests for ExceptionUtilities
- document the new tests in the changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68521f07f390832a87ca151ccbb08c0b