### PR TITLE
Add ExecutionResult JUnit test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 > * `EncryptionUtilities` now uses AES-GCM with random IV and PBKDF2-derived keys. Legacy cipher APIs are deprecated. Added SHA-384, SHA3-256, and SHA3-512 hashing support with improved input validation.
 > * Documentation for `EncryptionUtilities` updated to list all supported SHA algorithms and note heap buffer usage.
 > * `Executor` now uses `ProcessBuilder` with a 60-second timeout and provides an `ExecutionResult` API
+> * Added test for `ExecutionResult.getOut()` and `getError()`
 > * `IOUtilities` improved: configurable timeouts, `inputStreamToBytes` throws `IOException` with size limit, offset bug fixed in `uncompressBytes`
 > * `MathUtilities` now validates inputs for empty arrays and null lists, fixes documentation, and improves numeric parsing performance
 > * `ReflectionUtils` cache size is configurable via the `reflection.utils.cache.size` system property, uses

--- a/src/test/java/com/cedarsoftware/util/ExecutionResultTest.java
+++ b/src/test/java/com/cedarsoftware/util/ExecutionResultTest.java
@@ -1,0 +1,27 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ExecutionResultTest {
+
+    @Test
+    public void testGetOutAndErrorSuccess() {
+        Executor executor = new Executor();
+        ExecutionResult result = executor.execute("echo HelloWorld");
+        assertEquals(0, result.getExitCode());
+        assertEquals("HelloWorld", result.getOut().trim());
+        assertEquals("", result.getError());
+    }
+
+    @Test
+    public void testGetOutAndErrorFailure() {
+        Executor executor = new Executor();
+        ExecutionResult result = executor.execute("thisCommandShouldNotExist123");
+        assertNotEquals(0, result.getExitCode());
+        assertFalse(result.getError().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for ExecutionResult getters
- document the new test in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68521f72fbc4832aa6300aa2ceee62c5