### PR TITLE
Add Executor env and dir tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 > * `EncryptionUtilities` now uses AES-GCM with random IV and PBKDF2-derived keys. Legacy cipher APIs are deprecated. Added SHA-384, SHA3-256, and SHA3-512 hashing support with improved input validation.
 > * Documentation for `EncryptionUtilities` updated to list all supported SHA algorithms and note heap buffer usage.
 > * `Executor` now uses `ProcessBuilder` with a 60-second timeout and provides an `ExecutionResult` API
+> * Additional JUnit tests cover `Executor` methods for environment variables and working directories
 > * `IOUtilities` improved: configurable timeouts, `inputStreamToBytes` throws `IOException` with size limit, offset bug fixed in `uncompressBytes`
 > * `MathUtilities` now validates inputs for empty arrays and null lists, fixes documentation, and improves numeric parsing performance
 > * `ReflectionUtils` cache size is configurable via the `reflection.utils.cache.size` system property, uses

--- a/src/test/java/com/cedarsoftware/util/ExecutorAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/util/ExecutorAdditionalTest.java
@@ -1,0 +1,97 @@
+package com.cedarsoftware.util;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExecutorAdditionalTest {
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("windows");
+    }
+
+    private static String[] shellArray(String command) {
+        if (isWindows()) {
+            return new String[]{"cmd.exe", "/c", command};
+        }
+        return new String[]{"sh", "-c", command};
+    }
+
+    @Test
+    public void testExecuteArray() {
+        Executor executor = new Executor();
+        ExecutionResult result = executor.execute(shellArray("echo hello"));
+        assertEquals(0, result.getExitCode());
+        assertEquals("hello", result.getOut().trim());
+        assertEquals("", result.getError());
+    }
+
+    @Test
+    public void testExecuteCommandWithEnv() {
+        Executor executor = new Executor();
+        String command = isWindows() ? "echo %FOO%" : "echo $FOO";
+        ExecutionResult result = executor.execute(command, new String[]{"FOO=bar"});
+        assertEquals(0, result.getExitCode());
+        assertEquals("bar", result.getOut().trim());
+    }
+
+    @Test
+    public void testExecuteArrayWithEnv() {
+        Executor executor = new Executor();
+        String echoVar = isWindows() ? "echo %FOO%" : "echo $FOO";
+        ExecutionResult result = executor.execute(shellArray(echoVar), new String[]{"FOO=baz"});
+        assertEquals(0, result.getExitCode());
+        assertEquals("baz", result.getOut().trim());
+    }
+
+    @Test
+    public void testExecuteArrayWithEnvAndDir() throws Exception {
+        Executor executor = new Executor();
+        File dir = SystemUtilities.createTempDirectory("exec-test");
+        try {
+            String pwd = isWindows() ? "cd" : "pwd";
+            ExecutionResult result = executor.execute(shellArray(pwd), null, dir);
+            assertEquals(0, result.getExitCode());
+            assertEquals(dir.getAbsolutePath(), result.getOut().trim());
+        } finally {
+            if (dir != null) {
+                dir.delete();
+            }
+        }
+    }
+
+    @Test
+    public void testExecVariantsAndGetError() throws Exception {
+        Executor executor = new Executor();
+
+        assertEquals(0, executor.exec(shellArray("echo hi")));
+        assertEquals("hi", executor.getOut().trim());
+
+        String varCmd = isWindows() ? "echo %VAR%" : "echo $VAR";
+        assertEquals(0, executor.exec(varCmd, new String[]{"VAR=val"}));
+        assertEquals("val", executor.getOut().trim());
+
+        assertEquals(0, executor.exec(shellArray(varCmd), new String[]{"VAR=end"}));
+        assertEquals("end", executor.getOut().trim());
+
+        File dir = SystemUtilities.createTempDirectory("exec-test2");
+        try {
+            String pwd = isWindows() ? "cd" : "pwd";
+            assertEquals(0, executor.exec(pwd, null, dir));
+            assertEquals(dir.getAbsolutePath(), executor.getOut().trim());
+
+            assertEquals(0, executor.exec(shellArray(pwd), null, dir));
+            assertEquals(dir.getAbsolutePath(), executor.getOut().trim());
+        } finally {
+            if (dir != null) {
+                dir.delete();
+            }
+        }
+
+        String errCmd = isWindows() ? "echo err 1>&2" : "echo err 1>&2";
+        executor.exec(shellArray(errCmd));
+        assertEquals("err", executor.getError().trim());
+    }
+}


### PR DESCRIPTION
## Summary
- add additional tests for Executor covering environment and directory APIs
- document new Executor test coverage in changelog

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68522009b2f4832ab0f9ff0149f47209