### PR TITLE
Fix TypeHolder import in inner class test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 > * `StringUtilities.getRandomString()` validates parameters and throws descriptive exceptions.
 > * `StringUtilities.count()` uses a reliable substring search algorithm.
 > * Updated inner-class JSON test to match removal of synthetic `this$` fields.
+> * Fixed OverlappingMemberVariableNamesTest to use `com.cedarsoftware.io.TypeHolder`.
 > * `StringUtilities.hashCodeIgnoreCase()` updates locale compatibility when the default locale changes.
 > * `StringUtilities.commaSeparatedStringToSet()` returns a mutable empty set using `LinkedHashSet`.
 > * `StringUtilities` adds `snakeToCamel`, `camelToSnake`, `isNumeric`, `repeat`, `reverse`, `padLeft`, and `padRight` helpers.

--- a/src/test/java/com/cedarsoftware/io/OverlappingMemberVariableNamesTest.java
+++ b/src/test/java/com/cedarsoftware/io/OverlappingMemberVariableNamesTest.java
@@ -1,6 +1,6 @@
 package com.cedarsoftware.io;
 
-import com.cedarsoftware.util.TypeHolder;
+import com.cedarsoftware.io.TypeHolder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -40,7 +40,7 @@ public class OverlappingMemberVariableNamesTest {
         String json = JsonIo.toJson(outer, null);
         assertFalse(json.contains("this$"), "Outer reference should not be serialized");
 
-        Outer x = JsonIo.toJava(json, null).asType(TypeHolder.of(Outer.class));
+        Outer x = JsonIo.toJava(json, null).asType(new TypeHolder<Outer>() {});
 
         assertEquals("Joe Outer", x.getName());
         assertEquals("Jane Inner", x.getFoo().getName());


### PR DESCRIPTION
## Summary
- import `com.cedarsoftware.io.TypeHolder` in inner class test
- use anonymous `TypeHolder` instance when deserializing
- document test fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685220cf4b20832ab138d4c6fc4bfe53