### PR TITLE
Fix temp directory path handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,8 @@
 > * Deprecated `StringUtilities.createUtf8String(byte[])` removed; use `createUTF8String(byte[])` instead.
 > * `SystemUtilities` logs shutdown hook failures, handles missing network interfaces and returns immutable address lists
   `TestUtil.fetchResource`, `MapUtilities.cloneMapOfSets`, and core cache methods.
+> * `SystemUtilities.createTempDirectory()` now returns a canonical path so that
+  temporary directories resolve symlinks on macOS and other platforms.
 > * `TrackingMap` - `replaceContents()` replaces the misleading `setWrappedMap()` API. `keysUsed()` now returns an unmodifiable `Set<Object>` and `expungeUnused()` prunes stale keys.
 > * Fixed tests for `TrackingMap.replaceContents` and `setWrappedMap` to avoid tracking keys during verification
 > * `Unsafe` now obtains the sun.misc.Unsafe instance from the `theUnsafe` field instead of invoking its constructor, preventing JVM crashes during tests

--- a/src/main/java/com/cedarsoftware/util/SystemUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/SystemUtilities.java
@@ -194,7 +194,7 @@ public final class SystemUtilities
     public static File createTempDirectory(String prefix) throws IOException {
         File tempDir = Files.createTempDirectory(prefix).toFile();
         tempDir.deleteOnExit();
-        return tempDir;
+        return tempDir.getCanonicalFile();
     }
 
     /**

--- a/userguide.md
+++ b/userguide.md
@@ -3737,6 +3737,8 @@ SystemUtilities.addShutdownHook(() -> {
 File tempDir = SystemUtilities.createTempDirectory("prefix-");
 // Directory will be deleted on JVM exit
 ```
+The returned path is canonical, preventing issues with symbolic links such as
+`/var` versus `/private/var` on macOS.
 
 ### Version Management
 


### PR DESCRIPTION
## Summary
- return canonical path from `SystemUtilities.createTempDirectory`
- mention canonical path behavior in user guide
- note change in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852224528d8832ab38b054996afe674