### PR TITLE
Fix path comparison in tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,7 @@
 > * Custom map types under `com.cedarsoftware.io` allowed for `CompactMap`
 > * Added tests for `AbstractConcurrentNullSafeMap` entry equality and key set iterator removal
 > * Added JUnit tests for `ExceptionUtilities.safelyIgnoreException`
+> * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ExecutorAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/util/ExecutorAdditionalTest.java
@@ -54,7 +54,8 @@ public class ExecutorAdditionalTest {
             String pwd = isWindows() ? "cd" : "pwd";
             ExecutionResult result = executor.execute(shellArray(pwd), null, dir);
             assertEquals(0, result.getExitCode());
-            assertEquals(dir.getAbsolutePath(), result.getOut().trim());
+            String actualPath = new File(result.getOut().trim()).getCanonicalPath();
+            assertEquals(dir.getCanonicalPath(), actualPath);
         } finally {
             if (dir != null) {
                 dir.delete();
@@ -80,10 +81,12 @@ public class ExecutorAdditionalTest {
         try {
             String pwd = isWindows() ? "cd" : "pwd";
             assertEquals(0, executor.exec(pwd, null, dir));
-            assertEquals(dir.getAbsolutePath(), executor.getOut().trim());
+            String outPath = new File(executor.getOut().trim()).getCanonicalPath();
+            assertEquals(dir.getCanonicalPath(), outPath);
 
             assertEquals(0, executor.exec(shellArray(pwd), null, dir));
-            assertEquals(dir.getAbsolutePath(), executor.getOut().trim());
+            outPath = new File(executor.getOut().trim()).getCanonicalPath();
+            assertEquals(dir.getCanonicalPath(), outPath);
         } finally {
             if (dir != null) {
                 dir.delete();


### PR DESCRIPTION
## Summary
- fix ExecutorAdditionalTest path comparisons using canonical paths
- update changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685222686438832a80c0fe90e2a29e87