### PR TITLE
Add keySet tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
 > * Added tests for `AbstractConcurrentNullSafeMap` entry equality and key set iterator removal
 > * Added JUnit tests for `ExceptionUtilities.safelyIgnoreException`
 > * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
+> * Added tests for `ConcurrentNavigableMapNullSafe` keySet operations
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeKeySetTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeKeySetTest.java
@@ -1,0 +1,64 @@
+package com.cedarsoftware.util;
+
+import java.util.Iterator;
+import java.util.NavigableSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the keySet() view of ConcurrentNavigableMapNullSafe.
+ */
+class ConcurrentNavigableMapNullSafeKeySetTest {
+
+    @Test
+    void testKeySetOperations() {
+        ConcurrentNavigableMapNullSafe<String, Integer> map = new ConcurrentNavigableMapNullSafe<>();
+        map.put("a", 1);
+        map.put("b", 2);
+        map.put(null, 3);
+
+        NavigableSet<String> keys = map.keySet();
+
+        assertEquals(3, keys.size());
+        assertTrue(keys.contains("a"));
+        assertTrue(keys.contains(null));
+        assertFalse(keys.contains("c"));
+
+        assertTrue(keys.remove("b"));
+        assertFalse(map.containsKey("b"));
+        assertEquals(2, keys.size());
+
+        assertFalse(keys.remove("c"));
+
+        assertTrue(keys.remove(null));
+        assertFalse(map.containsKey(null));
+        assertEquals(1, keys.size());
+
+        keys.clear();
+        assertTrue(keys.isEmpty());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    void testIteratorRemove() {
+        ConcurrentNavigableMapNullSafe<String, Integer> map = new ConcurrentNavigableMapNullSafe<>();
+        map.put("a", 1);
+        map.put("b", 2);
+        map.put("c", 3);
+        map.put(null, 0);
+
+        NavigableSet<String> keys = map.keySet();
+        Iterator<String> it = keys.iterator();
+
+        while (it.hasNext()) {
+            String key = it.next();
+            it.remove();
+            assertFalse(map.containsKey(key));
+        }
+
+        assertTrue(map.isEmpty());
+        assertTrue(keys.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for ConcurrentNavigableMapNullSafe keySet view
- document new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685227730274832abd855bccb7373e4d