### PR TITLE
Add tests for ConcurrentNavigableSetNullSafe

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)
+> * Added unit tests for `ConcurrentNavigableSetNullSafe` convenience methods `subSet`, `headSet`, and `tailSet`
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeTest.java
@@ -529,4 +529,72 @@ class ConcurrentNavigableSetNullSafeTest {
         assertEquals(1, nullOnlySet.size());
         assertTrue(nullOnlySet.contains(null));
     }
+
+    @Test
+    void testSubSetDefault() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add("date");
+        set.add(null);
+
+        SortedSet<String> subSet = set.subSet("banana", "date");
+        assertEquals(2, subSet.size());
+        assertTrue(subSet.contains("banana"));
+        assertTrue(subSet.contains("cherry"));
+        assertFalse(subSet.contains("date"));
+        assertFalse(subSet.contains("apple"));
+        assertFalse(subSet.contains(null));
+
+        subSet.remove("banana");
+        assertFalse(set.contains("banana"));
+
+        subSet.add("blueberry");
+        assertTrue(set.contains("blueberry"));
+    }
+
+    @Test
+    void testHeadSetDefault() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add(null);
+
+        SortedSet<String> headSet = set.headSet("cherry");
+        assertEquals(2, headSet.size());
+        assertTrue(headSet.contains("apple"));
+        assertTrue(headSet.contains("banana"));
+        assertFalse(headSet.contains("cherry"));
+        assertFalse(headSet.contains(null));
+
+        headSet.remove("apple");
+        assertFalse(set.contains("apple"));
+
+        headSet.add("aardvark");
+        assertTrue(set.contains("aardvark"));
+    }
+
+    @Test
+    void testTailSetDefault() {
+        NavigableSet<String> set = new ConcurrentNavigableSetNullSafe<>();
+        set.add("apple");
+        set.add("banana");
+        set.add("cherry");
+        set.add(null);
+
+        SortedSet<String> tailSet = set.tailSet("banana");
+        assertEquals(3, tailSet.size());
+        assertTrue(tailSet.contains("banana"));
+        assertTrue(tailSet.contains("cherry"));
+        assertTrue(tailSet.contains(null));
+        assertFalse(tailSet.contains("apple"));
+
+        tailSet.remove(null);
+        assertFalse(set.contains(null));
+
+        tailSet.add("date");
+        assertTrue(set.contains("date"));
+    }
 }


### PR DESCRIPTION
## Summary
- add coverage for subSet(E,E), headSet(E) and tailSet(E)
- document test addition in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68522acfd1e0832aa95a42f02c8e7d6d