### PR TITLE
Add tests for comparator retrieval

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)
 > * Added unit tests for `ConcurrentNavigableSetNullSafe` convenience methods `subSet`, `headSet`, and `tailSet`
+> * Added tests for `ConcurrentNavigableSetNullSafe.comparator()`
 > * `ArrayUtilities` - new APIs `isNotEmpty`, `nullToEmpty`, and `lastIndexOf`; improved `createArray`, `removeItem`, `addItem`, `indexOf`, `contains`, and `toArray`
 > * `ClassUtilities` - safer class loading fallback, improved inner class instantiation and updated Javadocs
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeExtraTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableSetNullSafeExtraTest.java
@@ -1,0 +1,32 @@
+package com.cedarsoftware.util;
+
+import java.util.Comparator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Additional tests for ConcurrentNavigableSetNullSafe covering
+ * constructors and comparator retrieval.
+ */
+class ConcurrentNavigableSetNullSafeExtraTest {
+
+    @Test
+    void testDefaultComparatorIsNull() {
+        ConcurrentNavigableSetNullSafe<String> set = new ConcurrentNavigableSetNullSafe<>();
+        assertNull(set.comparator());
+    }
+
+    @Test
+    void testCustomComparatorRetention() {
+        Comparator<String> reverse = Comparator.reverseOrder();
+        ConcurrentNavigableSetNullSafe<String> set = new ConcurrentNavigableSetNullSafe<>(reverse);
+        assertSame(reverse, set.comparator());
+
+        set.add("a");
+        set.add("b");
+        set.add("c");
+        assertEquals("c", set.first());
+    }
+}


### PR DESCRIPTION
## Summary
- add new tests for `ConcurrentNavigableSetNullSafe.comparator()`
- document the added tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68522c804f90832aaea53b19da10d528