### PR TITLE
Fix Optional usage for JDK8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
 > * Added tests for `AbstractConcurrentNullSafeMap` entry equality and key set iterator removal
 > * Added JUnit tests for `ExceptionUtilities.safelyIgnoreException`
 > * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
+> * Updated `ConcurrentNavigableMapNullSafeEntryTest` to use `Optional.orElseThrow(NoSuchElementException::new)` for JDK 1.8 compatibility
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeEntryTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeEntryTest.java
@@ -3,6 +3,7 @@ package com.cedarsoftware.util;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ class ConcurrentNavigableMapNullSafeEntryTest {
         Map.Entry<String, Integer> entry = map.entrySet().stream()
                 .filter(e -> "a".equals(e.getKey()))
                 .findFirst()
-                .orElseThrow();
+                .orElseThrow(NoSuchElementException::new);
 
         assertEquals(1, entry.setValue(10));
         assertEquals(Integer.valueOf(10), map.get("a"));


### PR DESCRIPTION
## Summary
- update test to use Optional.orElseThrow(NoSuchElementException::new) for JDK 1.8
- note compatibility fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68522de1dcac832a96806d4169b7e4e2