### PR TITLE
Add tests for ConcurrentNavigableMapNullSafe entry wrapper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * Added JUnit tests for `ExceptionUtilities.safelyIgnoreException`
 > * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
 > * Updated `ConcurrentNavigableMapNullSafeEntryTest` to use `Optional.orElseThrow(NoSuchElementException::new)` for JDK 1.8 compatibility
+> * Added tests covering `Map.Entry` implementations returned by `ConcurrentNavigableMapNullSafe`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeEntryTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeEntryTest.java
@@ -55,4 +55,26 @@ class ConcurrentNavigableMapNullSafeEntryTest {
         assertEquals(Objects.hashCode(null) ^ Objects.hashCode(5), entry.hashCode());
         assertEquals("null=5", entry.toString());
     }
+
+    @Test
+    void testSetValueToNullAndToString() {
+        ConcurrentNavigableMapNullSafe<String, Integer> map = new ConcurrentNavigableMapNullSafe<>();
+        map.put("x", 7);
+
+        Map.Entry<String, Integer> entry = map.entrySet().iterator().next();
+
+        assertEquals(Integer.valueOf(7), entry.setValue(null));
+        assertNull(map.get("x"));
+        assertEquals("x=null", entry.toString());
+    }
+
+    @Test
+    void testEqualsWithNonEntryObject() {
+        ConcurrentNavigableMapNullSafe<String, Integer> map = new ConcurrentNavigableMapNullSafe<>();
+        map.put("key", 42);
+
+        Map.Entry<String, Integer> entry = map.entrySet().iterator().next();
+
+        assertNotEquals(entry, "notAnEntry");
+    }
 }


### PR DESCRIPTION
## Summary
- add extra unit tests for the `Map.Entry` wrapper returned by `ConcurrentNavigableMapNullSafe`
- document the new tests in the changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68522f96412c832abc98fec92ac2541d