### PR TITLE
Fix entry setValue implementation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * Added JUnit tests for `ExceptionUtilities.safelyIgnoreException`
 > * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
 > * Updated `ConcurrentNavigableMapNullSafeEntryTest` to use `Optional.orElseThrow(NoSuchElementException::new)` for JDK 1.8 compatibility
+> * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMap.java
+++ b/src/main/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMap.java
@@ -373,8 +373,9 @@ public abstract class AbstractConcurrentNullSafeMap<K, V> implements ConcurrentM
 
                             @Override
                             public V setValue(V value) {
-                                Object oldValue = internalEntry.setValue(maskNullValue(value));
-                                return unmaskNullValue(oldValue);
+                                Object keyObj = internalEntry.getKey();
+                                Object old = internalMap.put(keyObj, maskNullValue(value));
+                                return unmaskNullValue(old);
                             }
 
                             @Override

--- a/src/main/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafe.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafe.java
@@ -484,8 +484,9 @@ public class ConcurrentNavigableMapNullSafe<K, V> extends AbstractConcurrentNull
 
             @Override
             public V setValue(V value) {
-                Object oldValue = internalEntry.setValue(maskNullValue(value));
-                return unmaskNullValue(oldValue);
+                Object keyObj = internalEntry.getKey();
+                Object old = internalMap.put(keyObj, maskNullValue(value));
+                return unmaskNullValue(old);
             }
 
             @Override


### PR DESCRIPTION
## Summary
- ensure Map.Entry setValue updates backing map when underlying entries are immutable
- document bug fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68523011eba4832ab5782c51e360e154