### PR TITLE
Fix Map.Entry value sync

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,7 @@
 > * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
 > * Updated `ConcurrentNavigableMapNullSafeEntryTest` to use `Optional.orElseThrow(NoSuchElementException::new)` for JDK 1.8 compatibility
 > * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
+> * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMap.java
+++ b/src/main/java/com/cedarsoftware/util/AbstractConcurrentNullSafeMap.java
@@ -360,20 +360,20 @@ public abstract class AbstractConcurrentNullSafeMap<K, V> implements ConcurrentM
                     @Override
                     public Entry<K, V> next() {
                         Entry<Object, Object> internalEntry = it.next();
+                        final Object keyObj = internalEntry.getKey();
                         return new Entry<K, V>() {
                             @Override
                             public K getKey() {
-                                return unmaskNullKey(internalEntry.getKey());
+                                return unmaskNullKey(keyObj);
                             }
 
                             @Override
                             public V getValue() {
-                                return unmaskNullValue(internalEntry.getValue());
+                                return unmaskNullValue(internalMap.get(keyObj));
                             }
 
                             @Override
                             public V setValue(V value) {
-                                Object keyObj = internalEntry.getKey();
                                 Object old = internalMap.put(keyObj, maskNullValue(value));
                                 return unmaskNullValue(old);
                             }

--- a/src/main/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafe.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafe.java
@@ -470,21 +470,23 @@ public class ConcurrentNavigableMapNullSafe<K, V> extends AbstractConcurrentNull
      * @return the wrapped entry, or null if the internal entry is null
      */
     private Entry<K, V> wrapEntry(Entry<Object, Object> internalEntry) {
-        if (internalEntry == null) return null;
+        if (internalEntry == null) {
+            return null;
+        }
+        final Object keyObj = internalEntry.getKey();
         return new Entry<K, V>() {
             @Override
             public K getKey() {
-                return unmaskNullKey(internalEntry.getKey());
+                return unmaskNullKey(keyObj);
             }
 
             @Override
             public V getValue() {
-                return unmaskNullValue(internalEntry.getValue());
+                return unmaskNullValue(internalMap.get(keyObj));
             }
 
             @Override
             public V setValue(V value) {
-                Object keyObj = internalEntry.getKey();
                 Object old = internalMap.put(keyObj, maskNullValue(value));
                 return unmaskNullValue(old);
             }


### PR DESCRIPTION
## Summary
- ensure AbstractConcurrentNullSafeMap entry views read from the backing map
- fix ConcurrentNavigableMapNullSafe.wrapEntry to stay in sync
- note Map.Entry view update in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685231f4ec70832a8214c2b4f4cf239a