### PR TITLE
Fix poll entry value retrieval

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -50,6 +50,8 @@
 > * Updated `ConcurrentNavigableMapNullSafeEntryTest` to use `Optional.orElseThrow(NoSuchElementException::new)` for JDK 1.8 compatibility
 > * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
+> * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now
+  return correct values after removal
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafe.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafe.java
@@ -262,13 +262,23 @@ public class ConcurrentNavigableMapNullSafe<K, V> extends AbstractConcurrentNull
     @Override
     public Entry<K, V> pollFirstEntry() {
         Entry<Object, Object> entry = ((ConcurrentSkipListMap<Object, Object>) internalMap).pollFirstEntry();
-        return wrapEntry(entry);
+        if (entry == null) {
+            return null;
+        }
+        K key = unmaskNullKey(entry.getKey());
+        V value = unmaskNullValue(entry.getValue());
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
     }
 
     @Override
     public Entry<K, V> pollLastEntry() {
         Entry<Object, Object> entry = ((ConcurrentSkipListMap<Object, Object>) internalMap).pollLastEntry();
-        return wrapEntry(entry);
+        if (entry == null) {
+            return null;
+        }
+        K key = unmaskNullKey(entry.getKey());
+        V value = unmaskNullValue(entry.getValue());
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure pollFirstEntry/lastEntry keep removed value
- document fix in changelog

## Testing
- `mvn -q test` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685233a5f000832a823c1bba3db11fc3