### PR TITLE
Add missing ConcurrentSet tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now
   return correct values after removal
+> * Added JUnit tests for ConcurrentSet constructors and toString()
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentSetAdditionalTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentSetAdditionalTest.java
@@ -1,0 +1,56 @@
+package com.cedarsoftware.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConcurrentSetAdditionalTest {
+
+    @Test
+    void testConstructorFromCollection() {
+        Collection<String> col = new ArrayList<>(Arrays.asList("a", null, "b"));
+        ConcurrentSet<String> set = new ConcurrentSet<>(col);
+        assertEquals(3, set.size());
+        assertTrue(set.contains("a"));
+        assertTrue(set.contains("b"));
+        assertTrue(set.contains(null));
+
+        col.add("c");
+        assertFalse(set.contains("c"));
+    }
+
+    @Test
+    void testConstructorFromSet() {
+        Set<String> orig = new HashSet<>(Arrays.asList("x", null));
+        ConcurrentSet<String> set = new ConcurrentSet<>(orig);
+        assertEquals(2, set.size());
+        assertTrue(set.contains("x"));
+        assertTrue(set.contains(null));
+
+        orig.add("y");
+        assertFalse(set.contains("y"));
+    }
+
+    @Test
+    void testToStringOutput() {
+        ConcurrentSet<String> set = new ConcurrentSet<>();
+        assertEquals("{}", set.toString());
+
+        set.add("a");
+        set.add(null);
+        set.add("b");
+
+        String str = set.toString();
+        assertTrue(str.startsWith("{") && str.endsWith("}"), "String should start and end with braces");
+        String content = str.substring(1, str.length() - 1);
+        String[] parts = content.split(", ");
+        Set<String> tokens = new HashSet<>(Arrays.asList(parts));
+        assertEquals(new HashSet<>(Arrays.asList("a", "b", "null")), tokens);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for ConcurrentSet constructors
- add tests for ConcurrentSet.toString()
- document the new tests in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685236cb7a0c832aaecc1b528eefe65e