### PR TITLE
Add test for CompactMapComparator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### Revision History
 #### 3.3.3 AI/LLM review and updates
+> * Added test covering `CompactMapComparator.toString()`
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)

--- a/src/test/java/com/cedarsoftware/util/CompactMapComparatorTest.java
+++ b/src/test/java/com/cedarsoftware/util/CompactMapComparatorTest.java
@@ -1,0 +1,18 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for CompactMap.CompactMapComparator.
+ */
+public class CompactMapComparatorTest {
+
+    @Test
+    public void testToString() {
+        CompactMap.CompactMapComparator comparator = new CompactMap.CompactMapComparator(true, true);
+        String expected = "CompactMapComparator{caseInsensitive=true, reverse=true}";
+        assertEquals(expected, comparator.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- add CompactMapComparatorTest covering toString()
- document new test in the changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685237a83864832a91183676a981c7ea