### PR TITLE
Add tests for SafeSimpleDateFormat equality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
 > * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
+> * Added unit tests for `SafeSimpleDateFormat.equals()` and `.hashCode()`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/SafeSimpleDateFormatEqualsHashCodeTest.java
+++ b/src/test/java/com/cedarsoftware/util/SafeSimpleDateFormatEqualsHashCodeTest.java
@@ -1,0 +1,32 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class SafeSimpleDateFormatEqualsHashCodeTest {
+
+    @Test
+    void testEquals() {
+        SafeSimpleDateFormat df1 = new SafeSimpleDateFormat("yyyy-MM-dd");
+        SafeSimpleDateFormat df2 = new SafeSimpleDateFormat("yyyy-MM-dd");
+        SafeSimpleDateFormat df3 = new SafeSimpleDateFormat("MM/dd/yyyy");
+
+        assertEquals(df1, df2);
+        assertEquals(df2, df1);
+        assertEquals(df1, df1);
+        assertNotEquals(df1, df3);
+        assertNotEquals(df1, Boolean.TRUE);
+    }
+
+    @Test
+    void testHashCode() {
+        SafeSimpleDateFormat df1 = new SafeSimpleDateFormat("yyyy-MM-dd");
+        SafeSimpleDateFormat df2 = new SafeSimpleDateFormat("yyyy-MM-dd");
+        SafeSimpleDateFormat df3 = new SafeSimpleDateFormat("MM/dd/yyyy");
+
+        assertEquals(df1.hashCode(), df2.hashCode());
+        assertNotEquals(df1.hashCode(), df3.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for SafeSimpleDateFormat.equals and hashCode
- document new unit tests in the changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68523885f86c832ab918744cee9340eb