### PR TITLE
Add tests for StringUtilities overloads

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
+> * Added tests for `StringUtilities.equals(String, String)`, `equalsIgnoreCase(String, String)` and `isEmpty(CharSequence)`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/StringUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/StringUtilitiesTest.java
@@ -82,6 +82,39 @@ public class StringUtilitiesTest
     {
         assertTrue(StringUtilities.isEmpty(s));
     }
+
+    private static Stream<Arguments> charSequencesWithOnlyWhitespace() {
+        return Stream.of(
+                Arguments.of(new StringBuilder("  ")),
+                Arguments.of(new StringBuffer("\t\n")),
+                Arguments.of(new Segment(" \r".toCharArray(), 0, 2))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("charSequencesWithOnlyWhitespace")
+    void testIsEmpty_whenCharSequenceHasOnlyWhitespace_returnsTrue(CharSequence cs) {
+        assertTrue(StringUtilities.isEmpty(cs));
+    }
+
+    private static Stream<Arguments> charSequencesWithContent() {
+        return Stream.of(
+                Arguments.of(new StringBuilder("a")),
+                Arguments.of(new StringBuffer("b")),
+                Arguments.of(new Segment("foo".toCharArray(), 0, 3))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("charSequencesWithContent")
+    void testIsEmpty_whenCharSequenceHasContent_returnsFalse(CharSequence cs) {
+        assertFalse(StringUtilities.isEmpty(cs));
+    }
+
+    @Test
+    void testIsEmpty_whenCharSequenceIsNull_returnsTrue() {
+        assertTrue(StringUtilities.isEmpty((CharSequence) null));
+    }
     
     @ParameterizedTest
     @MethodSource("stringsWithAllWhitespace")
@@ -324,6 +357,68 @@ public class StringUtilitiesTest
     void testEqualsIgnoreCase_whenStringsAreNotEqualIgnoringCase_returnsFalse(CharSequence one, CharSequence two)
     {
         assertThat(StringUtilities.equalsIgnoreCase(one, two)).isFalse();
+    }
+
+    private static Stream<Arguments> stringEquals_caseSensitive() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of("", ""),
+                Arguments.of("foo", "foo")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("stringEquals_caseSensitive")
+    void testEquals_whenStringsAreEqual_returnsTrue(String one, String two) {
+        assertTrue(StringUtilities.equals(one, two));
+    }
+
+    private static Stream<Arguments> stringNotEqual_caseSensitive() {
+        return Stream.of(
+                Arguments.of(null, ""),
+                Arguments.of("", null),
+                Arguments.of("foo", "bar"),
+                Arguments.of("foo", "FOO"),
+                Arguments.of("foo", "food")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("stringNotEqual_caseSensitive")
+    void testEquals_whenStringsAreNotEqual_returnsFalse(String one, String two) {
+        assertFalse(StringUtilities.equals(one, two));
+    }
+
+    private static Stream<Arguments> stringEquals_ignoreCase() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of("", ""),
+                Arguments.of("foo", "foo"),
+                Arguments.of("FOO", "foo"),
+                Arguments.of("fOo", "FoO")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("stringEquals_ignoreCase")
+    void testEqualsIgnoreCase_whenStringsEqualIgnoringCase_returnsTrue(String one, String two) {
+        assertTrue(StringUtilities.equalsIgnoreCase(one, two));
+    }
+
+    private static Stream<Arguments> stringNotEqual_ignoreCase() {
+        return Stream.of(
+                Arguments.of(null, ""),
+                Arguments.of("", null),
+                Arguments.of("foo", "bar"),
+                Arguments.of("foo", "food"),
+                Arguments.of(" foo", "foo")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("stringNotEqual_ignoreCase")
+    void testEqualsIgnoreCase_whenStringsNotEqualIgnoringCase_returnsFalse(String one, String two) {
+        assertFalse(StringUtilities.equalsIgnoreCase(one, two));
     }
 
     private static Stream<Arguments> charSequenceEquals_afterTrimCaseSensitive() {


### PR DESCRIPTION
## Summary
- cover StringUtilities.equals(String, String)
- cover StringUtilities.equalsIgnoreCase(String, String)
- add CharSequence variants for isEmpty
- note new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852398884e0832aa25a696ac1898b7b