### PR TITLE
Fix SafeSimpleDateFormat caching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,8 @@
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * Added unit tests for `SafeSimpleDateFormat.equals()` and `.hashCode()`
+> * `SafeSimpleDateFormat.getDateFormat()` now uses `computeIfAbsent` and tests
+  verify thread-local caching behavior
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/SafeSimpleDateFormat.java
+++ b/src/main/java/com/cedarsoftware/util/SafeSimpleDateFormat.java
@@ -45,17 +45,7 @@ public class SafeSimpleDateFormat extends DateFormat
     public static SimpleDateFormat getDateFormat(String format)
     {
         Map<String, SimpleDateFormat> formatters = _dateFormats.get();
-        SimpleDateFormat formatter = formatters.get(format);
-        if (formatter == null)
-        {
-            formatter = new SimpleDateFormat(format);
-            SimpleDateFormat simpleDateFormatRef = formatters.putIfAbsent(format, formatter);
-            if (simpleDateFormatRef != null)
-            {
-                formatter = simpleDateFormatRef;
-            }
-        }
-        return formatter;
+        return formatters.computeIfAbsent(format, SimpleDateFormat::new);
     }
 
     public SafeSimpleDateFormat(String format)

--- a/src/test/java/com/cedarsoftware/util/SafeSimpleDateFormatGetDateFormatTest.java
+++ b/src/test/java/com/cedarsoftware/util/SafeSimpleDateFormatGetDateFormatTest.java
@@ -28,4 +28,30 @@ public class SafeSimpleDateFormatGetDateFormatTest {
         SimpleDateFormat main = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
         assertNotSame(main, holder[0], "Threads should not share cached formatter");
     }
+
+    @Test
+    void testDifferentFormatsReturnDifferentInstances() {
+        SimpleDateFormat df1 = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        SimpleDateFormat df2 = SafeSimpleDateFormat.getDateFormat("MM/dd/yyyy");
+        assertNotSame(df1, df2, "Different source strings should create different formatters");
+    }
+
+    @Test
+    void testThreadLocalCaching() throws Exception {
+        SimpleDateFormat main1 = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        SimpleDateFormat main2 = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        assertSame(main1, main2, "Expected cached formatter for same thread");
+
+        final SimpleDateFormat[] holder = new SimpleDateFormat[2];
+        Thread t = new Thread(() -> {
+            holder[0] = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+            holder[1] = SafeSimpleDateFormat.getDateFormat("yyyy-MM-dd");
+        });
+        t.start();
+        t.join();
+
+        assertNotSame(main1, holder[0], "Formatter should be unique per thread");
+        assertSame(holder[0], holder[1], "Same thread should reuse its formatter");
+    }
 }
+


### PR DESCRIPTION
## Summary
- ensure SafeSimpleDateFormat caches formatters using computeIfAbsent
- expand tests to validate per-thread caching behaviour
- document SafeSimpleDateFormat change in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68523c422348832ab69127f275deccca