### PR TITLE
Fix SafeSimpleDateFormat equality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### Revision History
 #### 3.3.3 AI/LLM review and updates
 > * Added test covering `CompactMapComparator.toString()`
+> * `SafeSimpleDateFormat.equals()` now correctly handles other `SafeSimpleDateFormat` instances.
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.
 > * Documentation explains how to route `java.util.logging` output to SLF4J, Logback, or Log4j 2 in the [README](README.md#redirecting-javautil-logging)

--- a/src/main/java/com/cedarsoftware/util/SafeSimpleDateFormat.java
+++ b/src/main/java/com/cedarsoftware/util/SafeSimpleDateFormat.java
@@ -113,7 +113,17 @@ public class SafeSimpleDateFormat extends DateFormat
 
     @Override
     public boolean equals(Object other) {
-        return getDateFormat(_format).equals(other);
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof SafeSimpleDateFormat) {
+            SafeSimpleDateFormat that = (SafeSimpleDateFormat) other;
+            return getDateFormat(_format).equals(getDateFormat(that._format));
+        }
+        if (other instanceof SimpleDateFormat) {
+            return getDateFormat(_format).equals(other);
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- fix `SafeSimpleDateFormat.equals` to compare other `SafeSimpleDateFormat`
- document change in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68523e604d50832ab574b3698749ac82