### PR TITLE
Fix TTLCache purge NPE

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
+> * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/TTLCache.java
+++ b/src/main/java/com/cedarsoftware/util/TTLCache.java
@@ -196,11 +196,12 @@ public class TTLCache<K, V> implements Map<K, V>, AutoCloseable {
         long currentTime = System.currentTimeMillis();
         for (Iterator<Map.Entry<K, CacheEntry<K, V>>> it = cacheMap.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<K, CacheEntry<K, V>> entry = it.next();
-            if (entry.getValue().expiryTime < currentTime) {
+            CacheEntry<K, V> cacheEntry = entry.getValue();
+            if (cacheEntry.expiryTime < currentTime) {
                 it.remove();
                 lock.lock();
                 try {
-                    unlink(entry.getValue().node);
+                    unlink(cacheEntry.node);
                 } finally {
                     lock.unlock();
                 }


### PR DESCRIPTION
## Summary
- avoid using removed map entry while purging TTLCache
- document TTLCache fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68523e95ed5c832aa3cc8bbbdbd80876