### PR TITLE
Fix TTLCache scheduler shutdown issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### Revision History
 #### 3.3.3 AI/LLM review and updates
+> * `TTLCache` now recreates its background scheduler if used after `TTLCache.shutdown()`.
 > * Added test covering `CompactMapComparator.toString()`
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.

--- a/src/main/java/com/cedarsoftware/util/TTLCache.java
+++ b/src/main/java/com/cedarsoftware/util/TTLCache.java
@@ -56,11 +56,22 @@ public class TTLCache<K, V> implements Map<K, V>, AutoCloseable {
     private PurgeTask purgeTask;
 
     // Static ScheduledExecutorService with a single thread
-    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread thread = new Thread(r, "TTLCache-Purge-Thread");
-        thread.setDaemon(true);
-        return thread;
-    });
+    private static volatile ScheduledExecutorService scheduler = createScheduler();
+
+    private static ScheduledExecutorService createScheduler() {
+        return Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "TTLCache-Purge-Thread");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    private static synchronized ScheduledExecutorService ensureScheduler() {
+        if (scheduler == null || scheduler.isShutdown() || scheduler.isTerminated()) {
+            scheduler = createScheduler();
+        }
+        return scheduler;
+    }
     
     /**
      * Constructs a TTLCache with the specified TTL.
@@ -119,7 +130,7 @@ public class TTLCache<K, V> implements Map<K, V>, AutoCloseable {
     private void schedulePurgeTask(long cleanupIntervalMillis) {
         WeakReference<TTLCache<?, ?>> cacheRef = new WeakReference<>(this);
         PurgeTask task = new PurgeTask(cacheRef);
-        ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(task, cleanupIntervalMillis, cleanupIntervalMillis, TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> future = ensureScheduler().scheduleAtFixedRate(task, cleanupIntervalMillis, cleanupIntervalMillis, TimeUnit.MILLISECONDS);
         task.setFuture(future);
         purgeTask = task;
     }
@@ -614,7 +625,10 @@ public class TTLCache<K, V> implements Map<K, V>, AutoCloseable {
     /**
      * Shuts down the shared scheduler. Call this method when your application is terminating.
      */
-    public static void shutdown() {
-        scheduler.shutdown();
+    public static synchronized void shutdown() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+            scheduler = null;
+        }
     }
 }

--- a/userguide.md
+++ b/userguide.md
@@ -858,6 +858,8 @@ try {
     // Handle shutdown failure
 }
 ```
+Calling `TTLCache.shutdown()` stops the shared scheduler. Creating a new
+`TTLCache` instance afterwards will automatically restart the scheduler.
 ---
 ## TrackingMap
 [Source](/src/main/java/com/cedarsoftware/util/TrackingMap.java)


### PR DESCRIPTION
## Summary
- make TTLCache's scheduler recreatable after shutdown
- document scheduler restart behavior in the user guide
- log this change in the changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68523f0d8fd4832a863b9bab68027557