### PR TITLE
Add GenericArrayTypeImpl equality tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,7 @@
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
+> * Added unit tests for `GenericArrayTypeImpl.equals()` and `hashCode()`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/GenericArrayTypeImplEqualsHashCodeTest.java
+++ b/src/test/java/com/cedarsoftware/util/GenericArrayTypeImplEqualsHashCodeTest.java
@@ -1,0 +1,46 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests equality and hash code for GenericArrayTypeImpl in TypeUtilities.
+ */
+public class GenericArrayTypeImplEqualsHashCodeTest {
+
+    public static class TestGeneric<T> {
+        public T[] arrayField;
+    }
+
+    public static class TestInteger extends TestGeneric<Integer> { }
+    public static class TestString extends TestGeneric<String> { }
+
+    @Test
+    public void testEqualsAndHashCode() throws Exception {
+        Field field = TestGeneric.class.getField("arrayField");
+        Type arrayType = field.getGenericType();
+
+        Type resolved1 = TypeUtilities.resolveType(TestInteger.class.getGenericSuperclass(), arrayType);
+        Type resolved2 = TypeUtilities.resolveType(TestInteger.class.getGenericSuperclass(), arrayType);
+        Type resolvedDiff = TypeUtilities.resolveType(TestString.class.getGenericSuperclass(), arrayType);
+
+        assertTrue(resolved1 instanceof GenericArrayType);
+        assertTrue(resolved2 instanceof GenericArrayType);
+        assertTrue(resolvedDiff instanceof GenericArrayType);
+
+        GenericArrayType gat1 = (GenericArrayType) resolved1;
+        GenericArrayType gat2 = (GenericArrayType) resolved2;
+        GenericArrayType gatDiff = (GenericArrayType) resolvedDiff;
+
+        assertEquals(gat1, gat2);
+        assertEquals(gat1.hashCode(), gat2.hashCode());
+
+        assertNotEquals(gat1, gatDiff);
+        assertNotEquals(gat1.hashCode(), gatDiff.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering GenericArrayTypeImpl equals and hashCode
- document the new tests in the changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852415883cc832ab37d09aa66a4dede