### PR TITLE
Improve UrlInvocationHandler docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 > * Fixed `ExecutorAdditionalTest` to compare canonical paths for cross-platform consistency
 > * Fixed `Map.Entry.setValue()` for entries from `ConcurrentNavigableMapNullSafe` and `AbstractConcurrentNullSafeMap` to update the backing map
 > * Map.Entry views now fetch values from the backing map so `toString()` and `equals()` reflect updates
+> * `UrlInvocationHandler` Javadoc clarified deprecation and pointed to modern HTTP clients
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 > * Added unit tests for `GenericArrayTypeImpl.equals()` and `hashCode()`

--- a/src/main/java/com/cedarsoftware/util/UrlInvocationHandler.java
+++ b/src/main/java/com/cedarsoftware/util/UrlInvocationHandler.java
@@ -6,34 +6,16 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 
 /**
- * Useful utility for allowing Java code to make Ajax calls, yet the Java code
- * can make these calls via Dynamic Proxies created from Java interfaces for
- * the remote server(s).
- *
- * Example:
- *
- * Assume you have a tomcat instance running a JSON Command Servlet, like com.cedarsoftware's or
- * Spring MVC.
- *
- * Assume you have a Java interface 'Explorer' that is mapped to a Java bean that you are allowing
- * to be called through RESTful JSON calls (Ajax / XHR).
- *
- * Explorer has methods on it, like getFiles(userId), etc.
- *
- * You need to use a SessionAware (JSESSIONID only) or CookieAware UrlInvocationHandler to interact
- * with the server so that the cookies will be placed on all requests.  In Javascript within browsers,
- * this is taken care of for you.  Not so in the Java side.
- * <pre>
- * Map cookies = new HashMap();
- * String url = "http://www.mycompany.com:80/json/"
- *
- * InvocationHandler handler = new UrlInvocationHandler(new UrlInvocationHandlerStrategyImplementation(url, ...));
- * Explorer explorer = (Explorer) ProxyFactory.create(Explorer.class, handler);
- *
- * At this point, your Java code can do this:
- *
- * List files = explorer.getFiles(userId);
- * </pre>
+ * Invocation handler that performs HTTP POST calls using a
+ * {@link UrlInvocationHandlerStrategy}.  It was originally designed to
+ * mimic Ajax-style requests via Java dynamic proxies.  The approach is no
+ * longer maintained and is kept solely for backward compatibility with
+ * legacy code such as n-cube.
+ * <p>
+ * Modern applications should prefer {@code java.net.http.HttpClient} or
+ * direct use of {@link UrlUtilities}.  This class may be removed in a
+ * future release.
+ * </p>
  *
  * @author Ken Partlow (kpartlow@gmail.com)
  * @author John DeRegnaucourt (jdereg@gmail.com)


### PR DESCRIPTION
## Summary
- clarify deprecated status of UrlInvocationHandler
- mention modern HTTP clients
- update changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685244bdede4832ab6f3875c0daf9b38