### PR TITLE
Modernize UrlUtilities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 > * Added unit tests for `GenericArrayTypeImpl.equals()` and `hashCode()`
+> * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/UrlUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/UrlUtilitiesTest.java
@@ -108,10 +108,10 @@ public class UrlUtilitiesTest {
         when(resp.getHeaderFieldKey(1)).thenReturn(UrlUtilities.SET_COOKIE);
         when(resp.getHeaderField(1)).thenReturn("ID=42; path=/");
         when(resp.getHeaderFieldKey(2)).thenReturn(null);
-        Map store = new ConcurrentHashMap();
+        Map<String, Map<String, Map<String, String>>> store = new ConcurrentHashMap<>();
         UrlUtilities.getCookies(resp, store);
         assertTrue(store.containsKey("example.com"));
-        Map cookie = (Map) ((Map) store.get("example.com")).get("ID");
+        Map<String, String> cookie = store.get("example.com").get("ID");
         assertEquals("42", cookie.get("ID"));
 
         HttpURLConnection req = mock(HttpURLConnection.class);
@@ -158,6 +158,14 @@ public class UrlUtilitiesTest {
         byte[] bytes = UrlUtilities.getContentFromUrl(url);
         assertEquals("hello", new String(bytes, StandardCharsets.UTF_8));
         assertEquals("hello", UrlUtilities.getContentFromUrlAsString(url));
+    }
+
+    @Test
+    void testCopyContentFromUrl() throws Exception {
+        String url = baseUrl + "/ok";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        UrlUtilities.copyContentFromUrl(url, out);
+        assertEquals("hello", out.toString(StandardCharsets.UTF_8.name()));
     }
 
     @Test

--- a/userguide.md
+++ b/userguide.md
@@ -4293,4 +4293,14 @@ For additional support or to report issues, please refer to the project's GitHub
 Call `LoggingConfig.init()` once during application startup. You may supply a
 custom timestamp pattern via `LoggingConfig.init("yyyy/MM/dd HH:mm:ss")` or the
 system property `ju.log.dateFormat`.
+## UrlUtilities
+[Source](/src/main/java/com/cedarsoftware/util/UrlUtilities.java)
+
+Utility methods for fetching HTTP/HTTPS content.
+
+### Key Features
+- Fetch content as `byte[]` or `String`
+- Stream directly to an `OutputStream` with `copyContentFromUrl`
+- Configurable default connect and read timeouts
+- Optional insecure SSL mode via `allowAllCerts` parameters
 


### PR DESCRIPTION
## Summary
- remove class deprecation and add thread-safe global fields
- add configurable connection timeouts
- default SSL cert validation to on
- improve cookie domain handling for multi-level TLDs
- provide new `copyContentFromUrl` streaming API
- update docs and tests

## Testing
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68524746845c832a98a1b3586e1f818c