### PR TITLE
Add substring search helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 > * `StringUtilities.count()` uses a reliable substring search algorithm.
 > * Updated inner-class JSON test to match removal of synthetic `this$` fields.
 > * `StringUtilities.hashCodeIgnoreCase()` updates locale compatibility when the default locale changes.
+> * `StringUtilities.indexOf()` provides a null-safe substring search API.
 > * `StringUtilities.commaSeparatedStringToSet()` returns a mutable empty set using `LinkedHashSet`.
 > * `StringUtilities` adds `snakeToCamel`, `camelToSnake`, `isNumeric`, `repeat`, `reverse`, `padLeft`, and `padRight` helpers.
 > * Constants `FOLDER_SEPARATOR` and `EMPTY` are now immutable (`final`).

--- a/src/main/java/com/cedarsoftware/util/StringUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/StringUtilities.java
@@ -361,6 +361,21 @@ public final class StringUtilities {
     }
 
     /**
+     * Find the first index of a substring within another string.
+     *
+     * @param outer the string to search, may be {@code null}
+     * @param inner the substring to find, may be {@code null}
+     * @return the index of {@code inner} within {@code outer}, or -1 if not found
+     *         or if either argument is {@code null}
+     */
+    public static int indexOf(String outer, String inner) {
+        if (outer == null || inner == null) {
+            return -1;
+        }
+        return outer.indexOf(inner);
+    }
+
+    /**
      * Convert a hexadecimal {@link String} into a byte array.
      *
      * <p>If the input length is odd or contains non-hex characters the method

--- a/src/test/java/com/cedarsoftware/util/StringUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/StringUtilitiesTest.java
@@ -973,4 +973,13 @@ public class StringUtilitiesTest
         assertEquals("A", StringUtilities.getRandomChar(random, true));
         assertEquals("h", StringUtilities.getRandomChar(random, false));
     }
+
+    @Test
+    void testIndexOf() {
+        assertEquals(0, StringUtilities.indexOf("abcd", "ab"));
+        assertEquals(2, StringUtilities.indexOf("abcd", "cd"));
+        assertEquals(-1, StringUtilities.indexOf("abcd", "ef"));
+        assertEquals(-1, StringUtilities.indexOf(null, "a"));
+        assertEquals(-1, StringUtilities.indexOf("abcd", null));
+    }
 }

--- a/userguide.md
+++ b/userguide.md
@@ -3421,8 +3421,9 @@ public static int length(CharSequence cs)
 public static int length(String s)
 public static int trimLength(String s)
 public static int lastIndexOf(String path, char ch)
-    
-// ASCII Hex     
+public static int indexOf(String outer, String inner)
+
+// ASCII Hex
 public static byte[] decode(String s)
 public static String encode(byte[] bytes)
 
@@ -3584,6 +3585,7 @@ int hash = StringUtilities.hashCodeIgnoreCase("Text");
 // Optimized string counting
 int count = StringUtilities.count("text", 't');
 int count = StringUtilities.count("text text", "text");
+int index = StringUtilities.indexOf("hello world", "world"); // 6
 ```
 
 `count` now uses a standard `indexOf` loop to avoid overlap issues.


### PR DESCRIPTION
## Summary
- add `indexOf` method to `StringUtilities` for null-safe substring search
- test new helper in `StringUtilitiesTest`
- document `indexOf` in user guide and changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852de708180832abc1365e51f29dcf2