### PR TITLE
Add negative tests for mapOf

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,7 @@
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 > * Added unit tests for `GenericArrayTypeImpl.equals()` and `hashCode()`
+> * Added negative tests for `MapUtilities.mapOf` input validation
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.

--- a/src/test/java/com/cedarsoftware/util/MapUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/MapUtilitiesTest.java
@@ -238,6 +238,32 @@ public class MapUtilitiesTest
     }
 
     @Test
+    public void testMapOfNullReturnsEmpty()
+    {
+        Map<Object, Object> map = MapUtilities.mapOf((Object[]) null);
+
+        assertTrue(map.isEmpty());
+        assertThrows(UnsupportedOperationException.class, () -> map.put("k", 1));
+    }
+
+    @Test
+    public void testMapOfOddArguments()
+    {
+        assertThrows(IllegalArgumentException.class, () -> MapUtilities.mapOf("a", 1, "b"));
+    }
+
+    @Test
+    public void testMapOfTooManyEntries()
+    {
+        Object[] data = new Object[22];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = i;
+        }
+
+        assertThrows(IllegalArgumentException.class, () -> MapUtilities.mapOf(data));
+    }
+
+    @Test
     public void testMapToString()
     {
         Map<String, Integer> map = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary
- add MapUtilities.mapOf negative tests
- document new tests in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68547cfd2624832abf34e1b52efb587e