### PR TITLE
Add tests for MapUtilities.getUnderlyingMap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -59,6 +59,7 @@
 > * Added unit tests for `GenericArrayTypeImpl.equals()` and `hashCode()`
 > * Added negative tests for `MapUtilities.mapOf` input validation
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
+> * Added tests for `MapUtilities.getUnderlyingMap` covering wrapper unwrapping and cycle detection
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/MapUtilitiesUnderlyingMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/MapUtilitiesUnderlyingMapTest.java
@@ -1,0 +1,78 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MapUtilitiesUnderlyingMapTest {
+
+    private Map<?, ?> invoke(Map<?, ?> map) throws Exception {
+        Method m = MapUtilities.class.getDeclaredMethod("getUnderlyingMap", Map.class);
+        m.setAccessible(true);
+        return (Map<?, ?>) m.invoke(null, map);
+    }
+
+    @Test
+    public void nullInputReturnsNull() throws Exception {
+        assertNull(invoke(null));
+    }
+
+    @Test
+    public void detectsCircularDependency() throws Exception {
+        CaseInsensitiveMap<String, String> ci = new CaseInsensitiveMap<>();
+        TrackingMap<String, String> tracking = new TrackingMap<>(ci);
+        Field mapField = CaseInsensitiveMap.class.getDeclaredField("map");
+        mapField.setAccessible(true);
+        mapField.set(ci, tracking);
+
+        Method m = MapUtilities.class.getDeclaredMethod("getUnderlyingMap", Map.class);
+        m.setAccessible(true);
+        InvocationTargetException ex = assertThrows(InvocationTargetException.class, () -> m.invoke(null, ci));
+        assertTrue(ex.getCause() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void unwrapsCompactMapWhenMap() throws Exception {
+        CompactMap<String, String> compact = new CompactMap<>();
+        Map<String, String> inner = new HashMap<>();
+        Field valField = CompactMap.class.getDeclaredField("val");
+        valField.setAccessible(true);
+        valField.set(compact, inner);
+
+        assertSame(inner, invoke(compact));
+    }
+
+    @Test
+    public void returnsCompactMapWhenNotMap() throws Exception {
+        CompactMap<String, String> compact = new CompactMap<>();
+        assertSame(compact, invoke(compact));
+    }
+
+    @Test
+    public void unwrapsCaseInsensitiveMap() throws Exception {
+        CaseInsensitiveMap<String, String> ci = new CaseInsensitiveMap<>();
+        Field mapField = CaseInsensitiveMap.class.getDeclaredField("map");
+        mapField.setAccessible(true);
+        Map<?, ?> inner = (Map<?, ?>) mapField.get(ci);
+        assertSame(inner, invoke(ci));
+    }
+
+    @Test
+    public void unwrapsTrackingMap() throws Exception {
+        Map<String, String> inner = new HashMap<>();
+        TrackingMap<String, String> tracking = new TrackingMap<>(inner);
+        assertSame(inner, invoke(tracking));
+    }
+
+    @Test
+    public void baseMapReturnedDirectly() throws Exception {
+        Map<String, String> map = new HashMap<>();
+        assertSame(map, invoke(map));
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/MapUtilitiesUnderlyingMapTest.java
+++ b/src/test/java/com/cedarsoftware/util/MapUtilitiesUnderlyingMapTest.java
@@ -13,8 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MapUtilitiesUnderlyingMapTest {
 
     private Map<?, ?> invoke(Map<?, ?> map) throws Exception {
-        Method m = MapUtilities.class.getDeclaredMethod("getUnderlyingMap", Map.class);
-        m.setAccessible(true);
+        Method m = ReflectionUtils.getMethod(MapUtilities.class, "getUnderlyingMap", Map.class);
         return (Map<?, ?>) m.invoke(null, map);
     }
 
@@ -27,12 +26,10 @@ public class MapUtilitiesUnderlyingMapTest {
     public void detectsCircularDependency() throws Exception {
         CaseInsensitiveMap<String, String> ci = new CaseInsensitiveMap<>();
         TrackingMap<String, String> tracking = new TrackingMap<>(ci);
-        Field mapField = CaseInsensitiveMap.class.getDeclaredField("map");
-        mapField.setAccessible(true);
+        Field mapField = ReflectionUtils.getField(CaseInsensitiveMap.class, "map");
         mapField.set(ci, tracking);
 
-        Method m = MapUtilities.class.getDeclaredMethod("getUnderlyingMap", Map.class);
-        m.setAccessible(true);
+        Method m = ReflectionUtils.getMethod(MapUtilities.class, "getUnderlyingMap", Map.class);
         InvocationTargetException ex = assertThrows(InvocationTargetException.class, () -> m.invoke(null, ci));
         assertTrue(ex.getCause() instanceof IllegalArgumentException);
     }
@@ -41,8 +38,7 @@ public class MapUtilitiesUnderlyingMapTest {
     public void unwrapsCompactMapWhenMap() throws Exception {
         CompactMap<String, String> compact = new CompactMap<>();
         Map<String, String> inner = new HashMap<>();
-        Field valField = CompactMap.class.getDeclaredField("val");
-        valField.setAccessible(true);
+        Field valField = ReflectionUtils.getField(CompactMap.class, "val");
         valField.set(compact, inner);
 
         assertSame(inner, invoke(compact));
@@ -57,8 +53,7 @@ public class MapUtilitiesUnderlyingMapTest {
     @Test
     public void unwrapsCaseInsensitiveMap() throws Exception {
         CaseInsensitiveMap<String, String> ci = new CaseInsensitiveMap<>();
-        Field mapField = CaseInsensitiveMap.class.getDeclaredField("map");
-        mapField.setAccessible(true);
+        Field mapField = ReflectionUtils.getField(CaseInsensitiveMap.class, "map");
         Map<?, ?> inner = (Map<?, ?>) mapField.get(ci);
         assertSame(inner, invoke(ci));
     }


### PR DESCRIPTION
## Summary
- add JUnit tests for the private `MapUtilities.getUnderlyingMap` method
- document the additional tests in `changelog.md`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854825ebcdc832ab95ea1d00f8184bb