### PR TITLE
Fix map unwrapping cycle detection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,7 @@
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
+> * `MapUtilities.getUnderlyingMap()` now uses identity comparison to avoid false cycle detection with wrapper maps
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/main/java/com/cedarsoftware/util/MapUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/MapUtilities.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -294,7 +295,9 @@ public class MapUtilities {
             return null;
         }
 
-        Set<Map<?, ?>> seen = new HashSet<>();
+        // Use identity semantics to avoid false cycle detection when wrapper
+        // maps implement equals() by delegating to their wrapped map.
+        Set<Map<?, ?>> seen = Collections.newSetFromMap(new IdentityHashMap<Map<?, ?>, Boolean>());
         Map<?, ?> current = map;
         List<String> path = new ArrayList<>();
         path.add(current.getClass().getSimpleName());
@@ -352,7 +355,9 @@ public class MapUtilities {
         if (map == null) return "null";
 
         List<String> structure = new ArrayList<>();
-        Set<Map<?, ?>> seen = new HashSet<>();
+        // Use identity semantics so wrapper maps that compare equal to their
+        // wrapped map do not trigger false cycles.
+        Set<Map<?, ?>> seen = Collections.newSetFromMap(new IdentityHashMap<Map<?, ?>, Boolean>());
         Map<?, ?> current = map;
 
         while (true) {


### PR DESCRIPTION
## Summary
- avoid false cycle detection in `MapUtilities.getUnderlyingMap()`
- make `getMapStructureString()` use identity semantics
- document fix in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854866a57c4832aacc6fc767762f042