### PR TITLE
Add tests for detectMapOrdering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 > * `TTLCache` now recreates its background scheduler if used after `TTLCache.shutdown()`.
 > * Added test covering `CompactMapComparator.toString()`
 > * Added tests covering `MapUtilities.getMapStructureString()`
+> * Added tests covering `MapUtilities.detectMapOrdering()`
 > * `SafeSimpleDateFormat.equals()` now correctly handles other `SafeSimpleDateFormat` instances.
 > * Manifest cleaned up by removing `Import-Package` entries for `java.sql` and `java.xml`
 > * All `System.out` and `System.err` prints replaced with `java.util.logging.Logger` usage.

--- a/src/test/java/com/cedarsoftware/util/MapUtilitiesDetectMapOrderingTest.java
+++ b/src/test/java/com/cedarsoftware/util/MapUtilitiesDetectMapOrderingTest.java
@@ -1,0 +1,56 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static com.cedarsoftware.util.CompactMap.INSERTION;
+import static com.cedarsoftware.util.CompactMap.SORTED;
+import static com.cedarsoftware.util.CompactMap.UNORDERED;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MapUtilitiesDetectMapOrderingTest {
+
+    @Test
+    public void nullInputReturnsUnordered() {
+        assertEquals(UNORDERED, MapUtilities.detectMapOrdering(null));
+    }
+
+    @Test
+    public void underlyingCompactMapFromWrapper() {
+        CompactMap<String, String> compact = new CompactMap<>();
+        CaseInsensitiveMap<String, String> wrapper =
+                new CaseInsensitiveMap<>(Collections.emptyMap(), compact);
+        assertEquals(compact.getOrdering(), MapUtilities.detectMapOrdering(wrapper));
+    }
+
+    @Test
+    public void sortedMapReturnsSorted() {
+        assertEquals(SORTED, MapUtilities.detectMapOrdering(new TreeMap<>()));
+    }
+
+    @Test
+    public void linkedHashMapReturnsInsertion() {
+        assertEquals(INSERTION, MapUtilities.detectMapOrdering(new LinkedHashMap<>()));
+    }
+
+    @Test
+    public void hashMapReturnsUnordered() {
+        assertEquals(UNORDERED, MapUtilities.detectMapOrdering(new HashMap<>()));
+    }
+
+    @Test
+    public void circularDependencyException() throws Exception {
+        CaseInsensitiveMap<String, String> ci = new CaseInsensitiveMap<>();
+        TrackingMap<String, String> tracking = new TrackingMap<>(ci);
+        Field mapField = ReflectionUtils.getField(CaseInsensitiveMap.class, "map");
+        mapField.set(ci, tracking);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> MapUtilities.detectMapOrdering(ci));
+        assertTrue(ex.getMessage().startsWith(
+                "Cannot determine map ordering: Circular map structure detected"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add MapUtilitiesDetectMapOrderingTest covering null, wrapper, and ordering
- document the new tests in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68548b5be988832ab26528f99035ed77