### PR TITLE
Add tests for wrapComparator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 > * `CollectionConversions.arrayToCollection` now returns a type-safe collection
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
+> * Added tests covering wrapComparator null and mixed type handling
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeComparatorUtilTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeComparatorUtilTest.java
@@ -1,0 +1,80 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConcurrentNavigableMapNullSafeComparatorUtilTest {
+
+    @SuppressWarnings("unchecked")
+    private static Comparator<Object> getWrapped(Comparator<?> cmp) throws Exception {
+        Method m = ConcurrentNavigableMapNullSafe.class.getDeclaredMethod("wrapComparator", Comparator.class);
+        m.setAccessible(true);
+        return (Comparator<Object>) m.invoke(null, cmp);
+    }
+
+    @Test
+    void testActualNullHandling() throws Exception {
+        Comparator<Object> comp = getWrapped(null);
+        assertEquals(0, comp.compare(null, null));
+        assertEquals(-1, comp.compare(null, "a"));
+        assertEquals(1, comp.compare("a", null));
+    }
+
+    @Test
+    void testComparableObjects() throws Exception {
+        Comparator<Object> comp = getWrapped(null);
+        assertTrue(comp.compare("a", "b") < 0);
+        assertTrue(comp.compare("b", "a") > 0);
+        assertEquals(0, comp.compare("x", "x"));
+    }
+
+    @Test
+    void testDifferentNonComparableTypes() throws Exception {
+        Comparator<Object> comp = getWrapped(null);
+        Object one = new Object();
+        Long two = 5L;
+        int expected = one.getClass().getName().compareTo(two.getClass().getName());
+        assertEquals(expected, comp.compare(one, two));
+        assertEquals(-expected, comp.compare(two, one));
+    }
+
+    @Test
+    void testSameClassNameDifferentClassLoaders() throws Exception {
+        ClassLoader cl1 = new LoaderOne();
+        ClassLoader cl2 = new LoaderTwo();
+        Class<?> c1 = Class.forName("com.cedarsoftware.util.TestClass", true, cl1);
+        Class<?> c2 = Class.forName("com.cedarsoftware.util.TestClass", true, cl2);
+        Object o1 = c1.getDeclaredConstructor().newInstance();
+        Object o2 = c2.getDeclaredConstructor().newInstance();
+
+        Comparator<Object> comp = getWrapped(null);
+        int expected = cl1.getClass().getName().compareTo(cl2.getClass().getName());
+        assertEquals(expected, comp.compare(o1, o2));
+        assertEquals(-expected, comp.compare(o2, o1));
+    }
+
+    private static URL[] getUrls() throws Exception {
+        URL url = ConcurrentNavigableMapNullSafeComparatorUtilTest.class.getClassLoader().getResource("test.txt");
+        String path = url.getPath();
+        path = path.substring(0, path.length() - 8);
+        List<URL> urls = new ArrayList<>();
+        urls.add(new URL("file:" + path));
+        return urls.toArray(new URL[1]);
+    }
+
+    static class LoaderOne extends URLClassLoader {
+        LoaderOne() throws Exception { super(getUrls(), null); }
+    }
+
+    static class LoaderTwo extends URLClassLoader {
+        LoaderTwo() throws Exception { super(getUrls(), null); }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for wrapComparator in ConcurrentNavigableMapNullSafe
- document additional test coverage in changelog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854921b4404832a8cf8a30f3ca55e94