### PR TITLE
Fix comparator test expectation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 > * `CompactMap.getConfig()` returns the library default compact size for legacy subclasses.
 > * `ConcurrentHashMapNullSafe` - fixed race condition in `computeIfAbsent` and added constructor to specify concurrency level.
 > * Added tests covering wrapComparator null and mixed type handling
+> * Fixed test expectation for wrapComparator to place null keys last
 > * `StringConversions.toSqlDate` now preserves the time zone from ISO date strings instead of using the JVM default.
 > * `ConcurrentList` is now `final`, implements `Serializable` and `RandomAccess`, and uses a fair `ReentrantReadWriteLock` for balanced thread scheduling.
 > * `ConcurrentList.containsAll()` no longer allocates an intermediate `HashSet`.

--- a/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeComparatorUtilTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConcurrentNavigableMapNullSafeComparatorUtilTest.java
@@ -24,8 +24,8 @@ class ConcurrentNavigableMapNullSafeComparatorUtilTest {
     void testActualNullHandling() throws Exception {
         Comparator<Object> comp = getWrapped(null);
         assertEquals(0, comp.compare(null, null));
-        assertEquals(-1, comp.compare(null, "a"));
-        assertEquals(1, comp.compare("a", null));
+        assertEquals(1, comp.compare(null, "a"));
+        assertEquals(-1, comp.compare("a", null));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- correct null comparison expectations in `ConcurrentNavigableMapNullSafe` test
- document the fix in `changelog.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854a35995b8832aa091e90895192a9e