### PR TITLE
Add cache-backed type support checks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@
 > * `listIterator(int)` now returns a snapshot-based iterator instead of throwing `UnsupportedOperationException`.
 > * `withReadLockVoid()` now suppresses exceptions thrown by the provided `Runnable`
 > * `Converter` - factory conversions map made immutable and legacy caching code removed
+> * `Converter` now offers single-argument overloads of `isSimpleTypeConversionSupported`
+  and `isConversionSupportedFor` that cache self-type lookups
 > * `DateUtilities` uses `BigDecimal` for fractional second conversion, preventing rounding errors with high precision input
 > * `EncryptionUtilities` now uses AES-GCM with random IV and PBKDF2-derived keys. Legacy cipher APIs are deprecated. Added SHA-384, SHA3-256, and SHA3-512 hashing support with improved input validation.
 > * Documentation for `EncryptionUtilities` updated to list all supported SHA algorithms and note heap buffer usage.

--- a/src/main/java/com/cedarsoftware/util/Converter.java
+++ b/src/main/java/com/cedarsoftware/util/Converter.java
@@ -320,6 +320,17 @@ public final class Converter
     }
 
     /**
+     * Overload of {@link #isConversionSupportedFor(Class, Class)} that checks a single
+     * class for conversion support using cached results.
+     *
+     * @param type the class to query
+     * @return {@code true} if the converter supports this class
+     */
+    public static boolean isConversionSupportedFor(Class<?> type) {
+        return instance.isConversionSupportedFor(type);
+    }
+
+    /**
      * Determines whether a conversion from the specified source type to the target type is supported,
      * excluding any conversions involving arrays or collections.
      *
@@ -356,6 +367,17 @@ public final class Converter
      */
     public static boolean isSimpleTypeConversionSupported(Class<?> source, Class<?> target) {
         return instance.isSimpleTypeConversionSupported(source, target);
+    }
+
+    /**
+     * Overload of {@link #isSimpleTypeConversionSupported(Class, Class)} for querying
+     * if a single class is treated as a simple type. Results are cached.
+     *
+     * @param type the class to check
+     * @return {@code true} if the class is a simple convertible type
+     */
+    public static boolean isSimpleTypeConversionSupported(Class<?> type) {
+        return instance.isSimpleTypeConversionSupported(type);
     }
     
     /**

--- a/src/test/java/com/cedarsoftware/util/ConverterLegacyApiTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConverterLegacyApiTest.java
@@ -19,6 +19,8 @@ import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -264,6 +266,15 @@ class ConverterLegacyApiTest {
         assertTrue(com.cedarsoftware.util.Converter.isSimpleTypeConversionSupported(String.class, Integer.class));
         assertFalse(com.cedarsoftware.util.Converter.isSimpleTypeConversionSupported(String[].class, Integer[].class));
         assertFalse(com.cedarsoftware.util.Converter.isSimpleTypeConversionSupported(java.util.List.class, java.util.Set.class));
+    }
+
+    @Test
+    void singleArgSupportChecks() {
+        assertTrue(Converter.isSimpleTypeConversionSupported(String.class));
+        assertFalse(Converter.isSimpleTypeConversionSupported(Map.class));
+
+        assertTrue(Converter.isConversionSupportedFor(UUID.class));
+        assertFalse(Converter.isConversionSupportedFor(Map.class));
     }
 
     @Test

--- a/src/test/java/com/cedarsoftware/util/convert/ConverterTest.java
+++ b/src/test/java/com/cedarsoftware/util/convert/ConverterTest.java
@@ -4321,6 +4321,16 @@ class ConverterTest
     }
 
     @Test
+    void testSingleArgSupport()
+    {
+        assert converter.isSimpleTypeConversionSupported(String.class);
+        assert !converter.isSimpleTypeConversionSupported(Map.class);
+
+        assert converter.isConversionSupportedFor(UUID.class);
+        assert !converter.isConversionSupportedFor(Map.class);
+    }
+
+    @Test
     void testNullTypeInput()
     {
         assertThatThrownBy(() -> converter.convert("foo", null))

--- a/userguide.md
+++ b/userguide.md
@@ -1986,6 +1986,10 @@ boolean directSupport = converter.isDirectConversionSupported(
 boolean simpleConvert = converter.isSimpleTypeConversionSupported(
         String.class, Date.class);    // built-in JDK types (BigDecimal, Atomic*,
 
+// Quick self-type checks using cached lookups
+boolean uuidSupported = converter.isConversionSupportedFor(UUID.class);
+boolean simpleType = converter.isSimpleTypeConversionSupported(String.class);
+
 // Fetch supported conversions (as Strings)
 Map<String, Set<String>> map = Converter.getSupportedConversions();
 


### PR DESCRIPTION
## Summary
- speed up `Converter` type checks
- add single-argument support methods with caching
- document new APIs in the user guide
- note addition in the changelog
- test single-argument support methods

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68549f930b84832a909f2e48937ae7e8