### PR TITLE
Add tests for static Converter API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -64,6 +64,7 @@
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
 > * `MapUtilities.getUnderlyingMap()` now uses identity comparison to avoid false cycle detection with wrapper maps
+> * Added tests for static `Converter` methods `isConversionSupportedFor`, `getSupportedConversions`, and `addConversion`
 #### 3.3.2 JDK 24+ Support
 > * `LRUCache` - `getCapacity()` API added so you can query/determine capacity of an `LRUCache` instance after it has been created.
 > * `SystemUtilities.currentJdkMajorVersion()` added to provide JDK8 thru JDK24 compatible way to get the JDK/JRE major version.

--- a/src/test/java/com/cedarsoftware/util/ConverterStaticMethodsTest.java
+++ b/src/test/java/com/cedarsoftware/util/ConverterStaticMethodsTest.java
@@ -1,0 +1,51 @@
+package com.cedarsoftware.util;
+
+import com.cedarsoftware.util.convert.Convert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConverterStaticMethodsTest {
+
+    private static class CustomType {
+        final String value;
+        CustomType(String value) { this.value = value; }
+    }
+
+    @Test
+    void conversionSupportDelegatesToInstance() {
+        assertTrue(Converter.isConversionSupportedFor(String.class, Integer.class));
+        assertFalse(Converter.isConversionSupportedFor(Map.class, Integer.class));
+    }
+
+    @Test
+    void getSupportedConversionsListsKnownTypes() {
+        Map<String, Set<String>> conversions = Converter.getSupportedConversions();
+        assertThat(conversions).isNotEmpty();
+        assertTrue(conversions.get("String").contains("Integer"));
+        assertEquals(Converter.allSupportedConversions().size(), conversions.size());
+    }
+
+    @Test
+    void addConversionAddsAndReplaces() {
+        Convert<CustomType> fn1 = (from, conv) -> new CustomType((String) from);
+        Convert<CustomType> fn2 = (from, conv) -> new CustomType(((String) from).toUpperCase());
+        try {
+            Convert<?> prev = Converter.addConversion(String.class, CustomType.class, fn1);
+            assertNull(prev);
+            CustomType result = Converter.convert("abc", CustomType.class);
+            assertEquals("abc", result.value);
+
+            prev = Converter.addConversion(String.class, CustomType.class, fn2);
+            assertSame(fn1, prev);
+            result = Converter.convert("abc", CustomType.class);
+            assertEquals("ABC", result.value);
+        } finally {
+            Converter.addConversion(String.class, CustomType.class, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover Converter static methods with unit tests
- document test addition in changelog

## Testing
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854a8582a48832aa8489015fdc9aa86