### PR TITLE
Add uncheckedThrow to ExceptionUtilities

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 > * Fixed `TTLCache.purgeExpiredEntries()` NPE when removing expired entries
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
 > * Logging instructions merged into `userguide.md`; README section condensed
+> * `ExceptionUtilities` adds private `uncheckedThrow` for rethrowing any `Throwable` unchecked
 #### 3.3.3 LLM inspired updates against the life-long "todo" list.
 > * `TTLCache` now recreates its background scheduler if used after `TTLCache.shutdown()`.
 > * `SafeSimpleDateFormat.equals()` now correctly handles other `SafeSimpleDateFormat` instances.

--- a/src/main/java/com/cedarsoftware/util/ExceptionUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ExceptionUtilities.java
@@ -3,7 +3,9 @@ package com.cedarsoftware.util;
 import java.util.concurrent.Callable;
 
 /**
- * Useful Exception Utilities
+ * Useful Exception Utilities. This class also provides the
+ * {@code uncheckedThrow(Throwable)} helper which allows rethrowing any
+ * {@link Throwable} without declaring it.
  *
  * @author Ken Partlow (kpartlow@gmail.com)
  *         <br>
@@ -113,5 +115,18 @@ public final class ExceptionUtilities {
         if (t instanceof OutOfMemoryError) {
             throw (OutOfMemoryError) t;
         }
+    }
+
+    /**
+     * Throws any {@link Throwable} without declaring it. Useful when converting
+     * Groovy code to Java or otherwise bypassing checked exceptions.
+     *
+     * @param t throwable to be rethrown unchecked
+     * @param <T> type parameter used to trick the compiler
+     * @throws T never actually thrown, but declared for compiler satisfaction
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void uncheckedThrow(Throwable t) throws T {
+        throw (T) t;  // the cast fools the compiler into thinking this is unchecked
     }
 }

--- a/src/test/java/com/cedarsoftware/util/ExceptionUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/ExceptionUtilitiesTest.java
@@ -93,4 +93,19 @@ public class ExceptionUtilitiesTest
         });
         assertTrue(ran.get());
     }
+
+    @Test
+    void testUncheckedThrowRethrows() throws Exception {
+        java.lang.reflect.Method m = ExceptionUtilities.class.getDeclaredMethod("uncheckedThrow", Throwable.class);
+        m.setAccessible(true);
+
+        assertThatExceptionOfType(java.io.IOException.class)
+                .isThrownBy(() -> {
+                    try {
+                        m.invoke(null, new java.io.IOException("fail"));
+                    } catch (java.lang.reflect.InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
+    }
 }

--- a/userguide.md
+++ b/userguide.md
@@ -2702,6 +2702,17 @@ String hash = EncryptionUtilities.calculateFileHash(channel, digest);
 This implementation provides a robust set of cryptographic utilities with emphasis on performance, security, and ease of use.
 
 ---
+## ExceptionUtilities
+[Source](/src/main/java/com/cedarsoftware/util/ExceptionUtilities.java)
+
+Utility helpers for dealing with {@link Throwable} instances.
+
+### Key Features
+- Retrieve the deepest nested cause with `getDeepestException`
+- Execute tasks while ignoring exceptions via `safelyIgnoreException`
+- Rethrow any exception without declaring it using the `uncheckedThrow` helper
+
+---
 ## Executor
 [Source](/src/main/java/com/cedarsoftware/util/Executor.java)
 


### PR DESCRIPTION
## Summary
- add `uncheckedThrow` to ExceptionUtilities and mention in class javadoc
- test new helper via reflection
- document ExceptionUtilities in user guide
- note addition in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68558ea879b8832aaa28e0aa9d5c6b6a