### PR TITLE
Use public ExceptionUtilities helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
 > * Logging instructions merged into `userguide.md`; README section condensed
 > * `ExceptionUtilities` adds private `uncheckedThrow` for rethrowing any `Throwable` unchecked
+> * Updated tests to use the now public `ExceptionUtilities.uncheckedThrow`
 #### 3.3.3 LLM inspired updates against the life-long "todo" list.
 > * `TTLCache` now recreates its background scheduler if used after `TTLCache.shutdown()`.
 > * `SafeSimpleDateFormat.equals()` now correctly handles other `SafeSimpleDateFormat` instances.

--- a/src/test/java/com/cedarsoftware/util/ExceptionUtilitiesTest.java
+++ b/src/test/java/com/cedarsoftware/util/ExceptionUtilitiesTest.java
@@ -95,17 +95,8 @@ public class ExceptionUtilitiesTest
     }
 
     @Test
-    void testUncheckedThrowRethrows() throws Exception {
-        java.lang.reflect.Method m = ExceptionUtilities.class.getDeclaredMethod("uncheckedThrow", Throwable.class);
-        m.setAccessible(true);
-
+    void testUncheckedThrowRethrows() {
         assertThatExceptionOfType(java.io.IOException.class)
-                .isThrownBy(() -> {
-                    try {
-                        m.invoke(null, new java.io.IOException("fail"));
-                    } catch (java.lang.reflect.InvocationTargetException e) {
-                        throw e.getCause();
-                    }
-                });
+                .isThrownBy(() -> ExceptionUtilities.uncheckedThrow(new java.io.IOException("fail")));
     }
 }


### PR DESCRIPTION
## Summary
- update `ExceptionUtilitiesTest` to call `ExceptionUtilities.uncheckedThrow`
- record test update in the changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685591429338832aaa07fb62c42c7a1f