### PR TITLE
Remove checked IOEs; use uncheckedThrow

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 > * `UrlUtilities` no longer deprecated; certificate validation defaults to on, provides streaming API and configurable timeouts
 > * Logging instructions merged into `userguide.md`; README section condensed
 > * `ExceptionUtilities` adds private `uncheckedThrow` for rethrowing any `Throwable` unchecked
+> * `IOUtilities` and related APIs now throw `IOException` unchecked
 #### 3.3.3 LLM inspired updates against the life-long "todo" list.
 > * `TTLCache` now recreates its background scheduler if used after `TTLCache.shutdown()`.
 > * `SafeSimpleDateFormat.equals()` now correctly handles other `SafeSimpleDateFormat` instances.

--- a/src/main/java/com/cedarsoftware/util/ReflectionUtils.java
+++ b/src/main/java/com/cedarsoftware/util/ReflectionUtils.java
@@ -1492,10 +1492,10 @@ public final class ReflectionUtils {
      *
      * @param byteCode byte[] of compiled byte code
      * @return String fully qualified class name
-     * @throws IOException if there are problems reading the byte code
+     * @throws IOException if there are problems reading the byte code (thrown as unchecked)
      * @throws IllegalStateException if the class file format is not recognized
      */
-    public static String getClassNameFromByteCode(byte[] byteCode) throws IOException {
+    public static String getClassNameFromByteCode(byte[] byteCode) {
         try (InputStream is = new ByteArrayInputStream(byteCode);
              DataInputStream dis = new DataInputStream(is)) {
 
@@ -1577,6 +1577,9 @@ public final class ReflectionUtils {
             int stringIndex = classes[thisClassIndex - 1];
             String className = strings[stringIndex - 1];
             return className.replace('/', '.');
+        } catch (IOException e) {
+            ExceptionUtilities.uncheckedThrow(e);
+            return null; // unreachable
         }
     }
 

--- a/src/main/java/com/cedarsoftware/util/SystemUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/SystemUtilities.java
@@ -189,12 +189,19 @@ public final class SystemUtilities
     }
 
     /**
-     * Create temporary directory that will be deleted on JVM exit
+     * Create temporary directory that will be deleted on JVM exit.
+     *
+     * @throws IOException if the directory cannot be created (thrown as unchecked)
      */
-    public static File createTempDirectory(String prefix) throws IOException {
-        File tempDir = Files.createTempDirectory(prefix).toFile();
-        tempDir.deleteOnExit();
-        return tempDir.getCanonicalFile();
+    public static File createTempDirectory(String prefix) {
+        try {
+            File tempDir = Files.createTempDirectory(prefix).toFile();
+            tempDir.deleteOnExit();
+            return tempDir.getCanonicalFile();
+        } catch (IOException e) {
+            ExceptionUtilities.uncheckedThrow(e);
+            return null; // unreachable
+        }
     }
 
     /**

--- a/userguide.md
+++ b/userguide.md
@@ -2379,6 +2379,9 @@ This implementation provides robust deep comparison capabilities with detailed d
 
 A comprehensive utility class for I/O operations, providing robust stream handling, compression, and resource management capabilities.
 
+All methods that perform I/O now throw {@link java.io.IOException} unchecked via
+`ExceptionUtilities.uncheckedThrow`, simplifying caller code.
+
 See [Redirecting java.util.logging](#redirecting-javautillogging) if you use a different logging framework.
 
 ### Key Features
@@ -2394,17 +2397,17 @@ See [Redirecting java.util.logging](#redirecting-javautillogging) if you use a d
 
 ```java
 // Streaming
-public static void transfer(InputStream s, File f, TransferCallback cb) throws UncheckedIOException
-public static void transfer(InputStream in, OutputStream out, TransferCallback cb) throws UncheckedIOException
-public static void transfer(InputStream in, byte[] bytes) throws UncheckedIOException
-public static void transfer(InputStream in, OutputStream out) throws UncheckedIOException
-public static void transfer(File f, URLConnection c, TransferCallback cb) throws UncheckedIOException
-public static void transfer(File file, OutputStream out) throws UncheckedIOException
-public static void transfer(URLConnection c, File f, TransferCallback cb) throws UncheckedIOException
-public static void transfer(URLConnection c, byte[] bytes) throws UncheckedIOException
-public static byte[] inputStreamToBytes(InputStream in) throws UncheckedIOException
-public static byte[] inputStreamToBytes(InputStream in, int maxSize) throws UncheckedIOException
-public static InputStream getInputStream(URLConnection c) throws UncheckedIOException
+public static void transfer(InputStream s, File f, TransferCallback cb)
+public static void transfer(InputStream in, OutputStream out, TransferCallback cb)
+public static void transfer(InputStream in, byte[] bytes)
+public static void transfer(InputStream in, OutputStream out)
+public static void transfer(File f, URLConnection c, TransferCallback cb)
+public static void transfer(File file, OutputStream out)
+public static void transfer(URLConnection c, File f, TransferCallback cb)
+public static void transfer(URLConnection c, byte[] bytes)
+public static byte[] inputStreamToBytes(InputStream in)
+public static byte[] inputStreamToBytes(InputStream in, int maxSize)
+public static InputStream getInputStream(URLConnection c)
     
 // Stream close    
 public static void close(XMLStreamReader reader)
@@ -2416,8 +2419,8 @@ public static void flush(Flushable f)
 public static void flush(XMLStreamWriter writer)
     
 // Compression     
-public static void compressBytes(ByteArrayOutputStream original, ByteArrayOutputStream compressed) throws UncheckedIOException
-public static void compressBytes(FastByteArrayOutputStream original, FastByteArrayOutputStream compressed) throws UncheckedIOException
+public static void compressBytes(ByteArrayOutputStream original, ByteArrayOutputStream compressed)
+public static void compressBytes(FastByteArrayOutputStream original, FastByteArrayOutputStream compressed)
 public static byte[] compressBytes(byte[] bytes)
 public static byte[] compressBytes(byte[] bytes, int offset, int len)
 public static byte[] uncompressBytes(byte[] bytes)


### PR DESCRIPTION
## Summary
- changed IOUtilities methods to rethrow `IOException` via `ExceptionUtilities.uncheckedThrow`
- updated SystemUtilities, ReflectionUtils, EncryptionUtilities and UrlUtilities to use the same pattern
- noted change in documentation and changelog
- updated user guide API listings

## Testing
- `mvn -q test` *(failed: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6855bfc3fdb8832aa2df3f907434c3c5