### PR TITLE
Expose default Converter instance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### Revision History
 #### 3.5.0 (Unreleased)
-#### 3.4.0 
+> * `Converter.getInstance()` exposes the default instance used by the static API
+#### 3.4.0
 > * `MapUtilities.getUnderlyingMap()` now uses identity comparison to avoid false cycle detection with wrapper maps
 > * `ConcurrentNavigableMapNullSafe.pollFirstEntry()` and `pollLastEntry()` now return correct values after removal
 > * `UrlInvocationHandler` (deprecated) was finally removed.

--- a/src/main/java/com/cedarsoftware/util/Converter.java
+++ b/src/main/java/com/cedarsoftware/util/Converter.java
@@ -148,6 +148,22 @@ public final class Converter
     private Converter() { }
 
     /**
+     * Provides access to the default {@link com.cedarsoftware.util.convert.Converter}
+     * instance used by this class.
+     * <p>
+     * The returned instance is created with {@link DefaultConverterOptions} and is
+     * the same one used by all static conversion APIs. It is immutable and
+     * thread-safe.
+     * </p>
+     *
+     * @return the default {@code Converter} instance
+     */
+    public static com.cedarsoftware.util.convert.Converter getInstance()
+    {
+        return instance;
+    }
+
+    /**
      * Converts the given source object to the specified target type.
      * <p>
      * The {@code convert} method serves as the primary API for transforming objects between various types.

--- a/userguide.md
+++ b/userguide.md
@@ -1921,6 +1921,7 @@ public static APIs on the `com.cedarsoftware.util.Converter` class.
 The instance API allows you to create a `com.cedarsoftware.util.converter.Converter` instance with a custom `ConverterOptions` object.  If you add custom conversions, they will be used by the `Converter` instance.
 You can also store arbitrary settings in the options via `getCustomOptions()` and retrieve them later with `getCustomOption(name)`.
 You can create as many instances of the Converter as needed.  Often though, the static API is sufficient.
+If you only use the static API but need an instance for integration with other frameworks, call `Converter.getInstance()` to obtain the default Converter.
 
 **Collection Conversions:**
 ```java


### PR DESCRIPTION
## Summary
- add `Converter.getInstance()` to access the default converter
- document new API in user guide
- note new API in changelog

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68582c7b2784832a8e508181f639b1c4