### PR TITLE
Use cached reflection APIs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 > * `Converter.getInstance()` exposes the default instance used by the static API
 > * `ClassUtilities.newInstance()` accepts `Map` arguments using parameter names and falls back to the no‑arg constructor
 > * `Converter.convert()` returns the source when assignment compatible (when no other conversion path is selected)
+> * Internal reflection now uses `ReflectionUtils` caching for better performance
 > * Throwable creation from a `Map` handles aliases and nested causes
 > * Jar file is built with `-parameters` flag going forward (increased the jar size by about 10K)
 #### 3.4.0

--- a/src/main/java/com/cedarsoftware/util/ClassUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/ClassUtilities.java
@@ -78,6 +78,7 @@ import java.util.SortedSet;
 import java.util.Stack;
 import java.util.StringJoiner;
 import java.util.TimeZone;
+import com.cedarsoftware.util.ReflectionUtils;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -883,28 +884,29 @@ public class ClassUtilities {
      */
     private static ClassLoader getOSGiClassLoader0(final Class<?> classFromBundle) {
         try {
-            // Load the FrameworkUtil class from OSGi
-            Class<?> frameworkUtilClass = Class.forName("org.osgi.framework.FrameworkUtil");
+            // Load the FrameworkUtil class from OSGi using the bundle's class loader
+            ClassLoader loader = classFromBundle.getClassLoader();
+            Class<?> frameworkUtilClass = forName("org.osgi.framework.FrameworkUtil", loader);
 
             // Get the getBundle(Class<?>) method
-            Method getBundleMethod = frameworkUtilClass.getMethod("getBundle", Class.class);
+            Method getBundleMethod = ReflectionUtils.getMethod(frameworkUtilClass, "getBundle", Class.class);
 
             // Invoke FrameworkUtil.getBundle(classFromBundle) to get the Bundle instance
             Object bundle = getBundleMethod.invoke(null, classFromBundle);
 
             if (bundle != null) {
                 // Get BundleWiring class
-                Class<?> bundleWiringClass = Class.forName("org.osgi.framework.wiring.BundleWiring");
+                Class<?> bundleWiringClass = forName("org.osgi.framework.wiring.BundleWiring", loader);
 
                 // Get the adapt(Class) method
-                Method adaptMethod = bundle.getClass().getMethod("adapt", Class.class);
+                Method adaptMethod = ReflectionUtils.getMethod(bundle.getClass(), "adapt", Class.class);
 
                 // Invoke bundle.adapt(BundleWiring.class) to get the BundleWiring instance
                 Object bundleWiring = adaptMethod.invoke(bundle, bundleWiringClass);
 
                 if (bundleWiring != null) {
                     // Get the getClassLoader() method from BundleWiring
-                    Method getClassLoaderMethod = bundleWiringClass.getMethod("getClassLoader");
+                    Method getClassLoaderMethod = ReflectionUtils.getMethod(bundleWiringClass, "getClassLoader");
 
                     // Invoke getClassLoader() to obtain the ClassLoader
                     Object classLoader = getClassLoaderMethod.invoke(bundleWiring);

--- a/src/main/java/com/cedarsoftware/util/SystemUtilities.java
+++ b/src/main/java/com/cedarsoftware/util/SystemUtilities.java
@@ -19,6 +19,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import com.cedarsoftware.util.LoggingConfig;
 import java.util.stream.Collectors;
+import java.lang.reflect.Method;
+import com.cedarsoftware.util.ReflectionUtils;
 
 /**
  * Utility class providing common system-level operations and information gathering capabilities.
@@ -144,9 +146,9 @@ public final class SystemUtilities
      */
     public static int currentJdkMajorVersion() {
         try {
-            java.lang.reflect.Method versionMethod = Runtime.class.getMethod("version");
+            Method versionMethod = ReflectionUtils.getMethod(Runtime.class, "version");
             Object v = versionMethod.invoke(Runtime.getRuntime());
-            java.lang.reflect.Method major = v.getClass().getMethod("major");
+            Method major = ReflectionUtils.getMethod(v.getClass(), "major");
             return (Integer) major.invoke(v);
         } catch (Exception ignored) {
             String spec = System.getProperty("java.specification.version");
@@ -156,10 +158,10 @@ public final class SystemUtilities
 
     private static int[] parseJavaVersionNumbers() {
         try {
-            java.lang.reflect.Method versionMethod = Runtime.class.getMethod("version");
+            Method versionMethod = ReflectionUtils.getMethod(Runtime.class, "version");
             Object v = versionMethod.invoke(Runtime.getRuntime());
-            java.lang.reflect.Method majorMethod = v.getClass().getMethod("major");
-            java.lang.reflect.Method minorMethod = v.getClass().getMethod("minor");
+            Method majorMethod = ReflectionUtils.getMethod(v.getClass(), "major");
+            Method minorMethod = ReflectionUtils.getMethod(v.getClass(), "minor");
             int major = (Integer) majorMethod.invoke(v);
             int minor = (Integer) minorMethod.invoke(v);
             return new int[]{major, minor};

--- a/src/main/java/com/cedarsoftware/util/Unsafe.java
+++ b/src/main/java/com/cedarsoftware/util/Unsafe.java
@@ -3,6 +3,7 @@ package com.cedarsoftware.util;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import com.cedarsoftware.util.ReflectionUtils;
 
 import static com.cedarsoftware.util.ClassUtilities.forName;
 import static com.cedarsoftware.util.ClassUtilities.trySetAccessible;
@@ -22,10 +23,10 @@ final class Unsafe
     public Unsafe() {
         try {
             Class<?> unsafeClass = forName("sun.misc.Unsafe", ClassUtilities.getClassLoader(Unsafe.class));
-            Field f = unsafeClass.getDeclaredField("theUnsafe");
+            Field f = ReflectionUtils.getField(unsafeClass, "theUnsafe");
             trySetAccessible(f);
             sunUnsafe = f.get(null);
-            allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+            allocateInstance = ReflectionUtils.getMethod(unsafeClass, "allocateInstance", Class.class);
             trySetAccessible(allocateInstance);
         }
         catch (Exception e) {
@@ -47,7 +48,7 @@ final class Unsafe
         }
 
         try {
-            return allocateInstance.invoke(sunUnsafe, clazz);
+            return ReflectionUtils.call(sunUnsafe, allocateInstance, clazz);
         }
         catch (IllegalAccessException | IllegalArgumentException e ) {
             String name = clazz.getName();


### PR DESCRIPTION
## Summary
- leverage `ReflectionUtils` caching for Java version queries
- use `ReflectionUtils` in `Unsafe`
- load OSGi classes with correct loader and cached reflection
- document reflection improvements in changelog

## Testing
- `mvn -q test` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858e6750b64832abc6979f1e5574a10