### PR TITLE
Add putIfAbsent support to MultiKeyMap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 >   * **Impact**: Minimal - fixes inconsistent behavior and provides migration path through feature options
 >   * **Rationale**: Eliminates confusion from mixed precision behavior and provides simple, memorable conversion rules
 > * Added `computeIfAbsent` support to `MultiKeyMap` for lazy value population
+> * Added `putIfAbsent` support to `MultiKeyMap` for atomic insert when key is missing or mapped to null
 
 #### 3.6.0
 > * **Feature Enhancement**: Added comprehensive `java.awt.Color` conversion support to `Converter`:

--- a/src/main/java/com/cedarsoftware/util/MultiKeyMap.java
+++ b/src/main/java/com/cedarsoftware/util/MultiKeyMap.java
@@ -1448,6 +1448,32 @@ public final class MultiKeyMap<V> implements Map<Object, V> {
     /**
      * {@inheritDoc}
      * <p>
+     * Uses a double-check locking pattern to avoid unnecessary synchronization
+     * when a value is already present. If the key is absent or currently mapped
+     * to {@code null}, the provided value is stored.
+     *
+     * @see Map#putIfAbsent(Object, Object)
+     */
+    @Override
+    public V putIfAbsent(Object key, V value) {
+        V existing = get(key);
+        if (existing != null) {
+            return existing;
+        }
+
+        synchronized (writeLock) {
+            existing = get(key);
+            if (existing == null) {
+                put(key, value);
+                return null;
+            }
+            return existing;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
      * Performs a double-check locking pattern to avoid unnecessary
      * synchronization when the value already exists. If the value is absent
      * or {@code null}, the mapping function is invoked and the result stored

--- a/src/test/java/com/cedarsoftware/util/MultiKeyMapPutIfAbsentTest.java
+++ b/src/test/java/com/cedarsoftware/util/MultiKeyMapPutIfAbsentTest.java
@@ -1,0 +1,51 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the putIfAbsent API on MultiKeyMap.
+ */
+class MultiKeyMapPutIfAbsentTest {
+
+    @Test
+    void testPutOnAbsentKey() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+
+        assertNull(map.putIfAbsent("a", "value"));
+        assertEquals("value", map.get("a"));
+    }
+
+    @Test
+    void testNoOverwriteWhenPresent() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("existing", "value");
+
+        assertEquals("value", map.putIfAbsent("existing", "new"));
+        assertEquals("value", map.get("existing"));
+    }
+
+    @Test
+    void testReplaceNullValue() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("nullKey", (String) null);
+
+        assertNull(map.putIfAbsent("nullKey", "filled"));
+        assertEquals("filled", map.get("nullKey"));
+    }
+
+    @Test
+    void testMultiKeyArrayAndCollection() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+
+        Object[] arrayKey = {"x", "y"};
+        assertNull(map.putIfAbsent(arrayKey, "array"));
+        assertEquals("array", map.get("x", "y"));
+
+        assertNull(map.putIfAbsent(Arrays.asList("a", "b"), "list"));
+        assertEquals("list", map.get("a", "b"));
+    }
+}

--- a/userguide.md
+++ b/userguide.md
@@ -2135,6 +2135,7 @@ A high-performance, thread-safe Map implementation that supports multi-dimension
 - **Map compatible**: Works with Map interface for existing code
 - **Escape hatch**: Force arrays to be single keys when needed
 - **computeIfAbsent support**: Lazily populate values when keys are missing
+- **putIfAbsent support**: Atomically add entries only when absent
 
 ### API Design Philosophy
 
@@ -2358,6 +2359,12 @@ MultiKeyMap<String> cache = new MultiKeyMap<>();
 String value = cache.computeIfAbsent(
         new Object[]{"region", id},
         k -> loadFromStore((Object[]) k));
+```
+
+**Atomic Insert with putIfAbsent:**
+```java
+MultiKeyMap<String> config = new MultiKeyMap<>();
+config.putIfAbsent(new Object[]{"env", "prod"}, "prodConfig");
 ```
 
 This implementation provides a clean, efficient alternative to composite key objects and nested Maps, with excellent performance characteristics and a developer-friendly API.


### PR DESCRIPTION
## Summary
- implement `putIfAbsent` in `MultiKeyMap`
- document the new API in the user guide and changelog
- add unit tests for `putIfAbsent`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_686afd9fa700832a94ec680f2416ad35