### PR TITLE
Add full ConcurrentMap support for MultiKeyMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ System.setProperty("io.debug.detailed.paths", "true");
 - **[ConcurrentHashMapNullSafe](userguide.md#concurrenthashmapnullsafe)** - Thread-safe HashMap supporting null keys and values
 - **[ConcurrentNavigableMapNullSafe](userguide.md#concurrentnavigablemapnullsafe)** - Thread-safe NavigableMap supporting null keys and values
 - **[ClassValueMap](userguide.md#classvaluemap)** - High-performance Map optimized for fast Class key lookups using JVM-optimized ClassValue
+- **[MultiKeyMap](userguide.md#multikeymap)** - Concurrent map supporting multi-dimensional keys
 
 ### Lists
 - **[ConcurrentList](userguide.md#concurrentlist)** - Thread-safe List implementation with flexible wrapping options

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 >   * **Rationale**: Eliminates confusion from mixed precision behavior and provides simple, memorable conversion rules
 > * Added `computeIfAbsent` support to `MultiKeyMap` for lazy value population
 > * Added `putIfAbsent` support to `MultiKeyMap` for atomic insert when key is missing or mapped to null
+> * Expanded `MultiKeyMap` to fully implement `ConcurrentMap`: added `computeIfPresent`, `compute`, `replace`, and `remove(key,value)`
 
 #### 3.6.0
 > * **Feature Enhancement**: Added comprehensive `java.awt.Color` conversion support to `Converter`:

--- a/src/test/java/com/cedarsoftware/util/MultiKeyMapComputeIfPresentTest.java
+++ b/src/test/java/com/cedarsoftware/util/MultiKeyMapComputeIfPresentTest.java
@@ -1,0 +1,53 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the computeIfPresent API on MultiKeyMap.
+ */
+class MultiKeyMapComputeIfPresentTest {
+
+    @Test
+    void testComputeIfPresentOnExistingKey() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("value", "a");
+
+        String result = map.computeIfPresent("a", (k, v) -> v + "-new");
+        assertEquals("value-new", result);
+        assertEquals("value-new", map.get("a"));
+    }
+
+    @Test
+    void testComputeIfPresentOnMissingKey() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        assertNull(map.computeIfPresent("missing", (k, v) -> "x"));
+        assertFalse(map.containsKey("missing"));
+    }
+
+    @Test
+    void testComputeIfPresentRemovesWhenNull() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("gone", "bye");
+        String result = map.computeIfPresent("gone", (k, v) -> null);
+        assertNull(result);
+        assertFalse(map.containsKey("gone"));
+    }
+
+    @Test
+    void testComputeIfPresentWithArraysAndCollections() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        Object[] arrayKey = {"x", "y"};
+        map.put("val", arrayKey);
+        map.computeIfPresent(arrayKey, (k, v) -> v + "1");
+        assertEquals("val1", map.get("x", "y"));
+
+        map.put("list", Arrays.asList("a", "b"));
+        map.computeIfPresent(Arrays.asList("a", "b"), (k, v) -> v + "2");
+        assertEquals("list2", map.get("a", "b"));
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/MultiKeyMapComputeTest.java
+++ b/src/test/java/com/cedarsoftware/util/MultiKeyMapComputeTest.java
@@ -1,0 +1,55 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the compute API on MultiKeyMap.
+ */
+class MultiKeyMapComputeTest {
+
+    @Test
+    void testComputeNewKey() {
+        MultiKeyMap<Integer> map = new MultiKeyMap<>(16);
+        Integer result = map.compute("a", (k, v) -> 1);
+        assertEquals(1, result);
+        assertEquals(1, map.get("a"));
+    }
+
+    @Test
+    void testComputeExistingKey() {
+        MultiKeyMap<Integer> map = new MultiKeyMap<>(16);
+        map.put(1, "a");
+        Integer result = map.compute("a", (k, v) -> v + 1);
+        assertEquals(2, result);
+        assertEquals(2, map.get("a"));
+    }
+
+    @Test
+    void testComputeToNullRemoves() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("x", "a");
+        map.compute("a", (k, v) -> null);
+        assertFalse(map.containsKey("a"));
+    }
+
+    @Test
+    void testComputeWithArrayKeys() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        Object[] key = {"k1", "k2"};
+        map.put("v1", key);
+        map.compute(key, (k, v) -> v + "2");
+        assertEquals("v12", map.get("k1", "k2"));
+    }
+
+    @Test
+    void testComputeWithCollectionKeys() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("v", Arrays.asList("a", "b"));
+        map.compute(Arrays.asList("a", "b"), (k, v) -> v + "3");
+        assertEquals("v3", map.get("a", "b"));
+    }
+}

--- a/src/test/java/com/cedarsoftware/util/MultiKeyMapConcurrentMapApiTest.java
+++ b/src/test/java/com/cedarsoftware/util/MultiKeyMapConcurrentMapApiTest.java
@@ -1,0 +1,31 @@
+package com.cedarsoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for additional ConcurrentMap APIs on MultiKeyMap.
+ */
+class MultiKeyMapConcurrentMapApiTest {
+
+    @Test
+    void testRemoveWithValue() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        map.put("val", "a");
+        assertFalse(map.remove("a", "x"));
+        assertTrue(map.remove("a", "val"));
+        assertFalse(map.containsKey("a"));
+    }
+
+    @Test
+    void testReplaceMethods() {
+        MultiKeyMap<String> map = new MultiKeyMap<>(16);
+        assertNull(map.replace("a", "x"));
+        map.put("orig", "a");
+        assertTrue(map.replace("a", "orig", "new"));
+        assertEquals("new", map.get("a"));
+        assertEquals("new", map.replace("a", "latest"));
+        assertEquals("latest", map.get("a"));
+    }
+}

--- a/userguide.md
+++ b/userguide.md
@@ -2121,7 +2121,7 @@ This implementation provides a robust set of utilities for class manipulation an
 ---
 ## MultiKeyMap
 
-[View Source](/src/main/java/com/cedarsoftware/util/convert/MultiKeyMap.java)
+[View Source](/src/main/java/com/cedarsoftware/util/MultiKeyMap.java)
 
 A high-performance, thread-safe Map implementation that supports multi-dimensional keys (N-key lookups). Instead of creating complex composite key objects or nested Maps, MultiKeyMap allows you to use multiple discrete values as a single logical key.
 
@@ -2136,6 +2136,7 @@ A high-performance, thread-safe Map implementation that supports multi-dimension
 - **Escape hatch**: Force arrays to be single keys when needed
 - **computeIfAbsent support**: Lazily populate values when keys are missing
 - **putIfAbsent support**: Atomically add entries only when absent
+- **computeIfPresent/compute support**: Full `ConcurrentMap` API for atomic updates
 
 ### API Design Philosophy
 


### PR DESCRIPTION
## Summary
- extend MultiKeyMap to implement `ConcurrentMap`
- add `computeIfPresent`, `compute`, `replace`, and value-based `remove`
- document new APIs in README, userguide, and changelog
- add tests covering new ConcurrentMap functionality

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b003128cc832a9ce93e9cb214d394