### PR TITLE
Fix concurrent iterator nulls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 #### 3.8.0 (Unreleased)
 > * **TEST FIX**: Stabilized `ConcurrentListIteratorTest.testReadFailsGracefullyWhenConcurrentRemoveShrinksList` by
 >   using a latch to reliably detect the expected exception under heavy load
+> * **BUG FIX**: Prevented null elements from appearing in iterator snapshots
+>   of `ConcurrentList` under extreme concurrency
 #### 3.7.0
 > * **MAJOR FEATURE**: Enhanced `MultiKeyMap` with N-dimensional array expansion support:
 >   * **N-Dimensional Array Expansion**: Nested arrays of any depth are automatically flattened recursively into multi-keys with sentinel preservation

--- a/src/main/java/com/cedarsoftware/util/ConcurrentList.java
+++ b/src/main/java/com/cedarsoftware/util/ConcurrentList.java
@@ -243,7 +243,12 @@ public final class ConcurrentList<E> implements List<E>, Deque<E>, RandomAccess,
             for (int i = 0; i < sz; i++) {
                 try {
                     Object element = get(i);
-                    result.add(element);
+                    if (element != null) {
+                        result.add(element);
+                    } else {
+                        // Element vanished due to concurrent removal
+                        break;
+                    }
                 } catch (IndexOutOfBoundsException e) {
                     // List shrunk during iteration - stop here and return what we have
                     break;
@@ -273,7 +278,12 @@ public final class ConcurrentList<E> implements List<E>, Deque<E>, RandomAccess,
             for (int i = 0; i < sz; i++) {
                 try {
                     T element = (T) get(i);
-                    result.add(element);
+                    if (element != null) {
+                        result.add(element);
+                    } else {
+                        // Element vanished due to concurrent removal
+                        break;
+                    }
                 } catch (IndexOutOfBoundsException e) {
                     // List shrunk during iteration - stop here and return what we have
                     break;


### PR DESCRIPTION
## Summary
- skip nulls that arise during snapshot creation in `ConcurrentList`
- document fix

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687bffed2000832abf8d4da56d687366