### PR TITLE
Update IntervalSet removal handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 >   using a latch to reliably detect the expected exception under heavy load
 > * **BUG FIX**: Prevented null elements from appearing in iterator snapshots
 >   of `ConcurrentList` under extreme concurrency
+> * **BUG FIX**: Corrected `IntervalSet` range removal for discrete types,
+>   enforced unique start keys in discrete mode, and removed unsupported
+>   `AtomicInteger` and `AtomicLong` from documentation.
 #### 3.7.0
 > * **MAJOR FEATURE**: Enhanced `MultiKeyMap` with N-dimensional array expansion support:
 >   * **N-Dimensional Array Expansion**: Nested arrays of any depth are automatically flattened recursively into multi-keys with sentinel preservation

--- a/userguide.md
+++ b/userguide.md
@@ -4013,7 +4013,7 @@ boolean dateVerified = auditLog.contains(targetDate);
 
 IntervalSet provides intelligent boundary calculation for interval splitting/merging operations across a wide range of types:
 
-- **Numeric**: Byte, Short, Integer, Long, Float, Double, BigInteger, BigDecimal, AtomicInteger, AtomicLong
+- **Numeric**: Byte, Short, Integer, Long, Float, Double, BigInteger, BigDecimal
 - **Character**: Character (Unicode-aware)
 - **Temporal**: Date, java.sql.Date, Time, Timestamp, Instant, LocalDate, LocalTime, LocalDateTime, ZonedDateTime, OffsetDateTime, OffsetTime, Duration
 - **Custom**: Any type implementing Comparable (with manual boundary handling if needed)


### PR DESCRIPTION
## Summary
- tweak changelog entry for IntervalSet
- enforce unique start keys when `autoMerge` is false
- redirect `remove` to use `removeRange`
- fix `removeRangeWithSplitting` boundary logic
- drop AtomicInteger/AtomicLong from supported types docs

## Testing
- ❌ `mvn -q test` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c6c6044e0832aacc09d6305081e9a