### PR TITLE
Refactor MultiKeyMap size handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@
 > * **BUG FIX**: Corrected `IntervalSet` range removal for discrete types,
 >   enforced unique start keys in discrete mode, and removed unsupported
 >   `AtomicInteger` and `AtomicLong` from documentation.
+> * **REFACTOR**: Simplified `MultiKeyMap` by removing the redundant
+>   volatile `size` field and relying on the existing `AtomicInteger` for
+>   size tracking.
 #### 3.7.0
 > * **MAJOR FEATURE**: Enhanced `MultiKeyMap` with N-dimensional array expansion support:
 >   * **N-Dimensional Array Expansion**: Nested arrays of any depth are automatically flattened recursively into multi-keys with sentinel preservation


### PR DESCRIPTION
## Summary
- remove redundant `size` field from `MultiKeyMap`
- rely exclusively on `atomicSize` for size calculations
- document change in `changelog.md`

## Testing
- `mvn -q test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687cdf7d43c8832a9a636ca7f51f9255